### PR TITLE
DBZ-2975: Add partition awareness to source task components

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2ChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ChangeEventSourceFactory.java
@@ -20,7 +20,7 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class Db2ChangeEventSourceFactory implements ChangeEventSourceFactory<Db2OffsetContext> {
+public class Db2ChangeEventSourceFactory implements ChangeEventSourceFactory<Db2Partition, Db2OffsetContext> {
 
     private final Db2ConnectorConfig configuration;
     private final Db2Connection dataConnection;
@@ -42,12 +42,12 @@ public class Db2ChangeEventSourceFactory implements ChangeEventSourceFactory<Db2
     }
 
     @Override
-    public SnapshotChangeEventSource<Db2OffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<Db2Partition, Db2OffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new Db2SnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock, snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource<Db2OffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<Db2Partition, Db2OffsetContext> getStreamingChangeEventSource() {
         return new Db2StreamingChangeEventSource(
                 configuration,
                 dataConnection,

--- a/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
+++ b/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
@@ -149,11 +149,6 @@ public class Db2OffsetContext implements OffsetContext {
         }
 
         @Override
-        public Map<String, ?> getPartition() {
-            return Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
-        }
-
-        @Override
         public Db2OffsetContext load(Map<String, ?> offset) {
             final Lsn changeLsn = Lsn.valueOf((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));

--- a/src/main/java/io/debezium/connector/db2/Db2Partition.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Partition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.debezium.connector.common.Partition;
+import io.debezium.util.Collect;
+
+public class Db2Partition implements Partition {
+    private static final String SERVER_PARTITION_KEY = "server";
+
+    private final String serverName;
+
+    public Db2Partition(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final Db2Partition other = (Db2Partition) obj;
+        return Objects.equals(serverName, other.serverName);
+    }
+
+    @Override
+    public int hashCode() {
+        return serverName.hashCode();
+    }
+
+    static class Provider implements Partition.Provider<Db2Partition> {
+        private final Db2ConnectorConfig connectorConfig;
+
+        Provider(Db2ConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Set<Db2Partition> getPartitions() {
+            return Collections.singleton(new Db2Partition(connectorConfig.getLogicalName()));
+        }
+    }
+}

--- a/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
@@ -27,7 +27,7 @@ import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
 import io.debezium.util.Clock;
 
-public class Db2SnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<Db2OffsetContext> {
+public class Db2SnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<Db2Partition, Db2OffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Db2SnapshotChangeEventSource.class);
 

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -54,7 +54,7 @@ import io.debezium.util.Metronome;
  *
  * @author Jiri Pechanec, Peter Urbanetz
  */
-public class Db2StreamingChangeEventSource implements StreamingChangeEventSource<Db2OffsetContext> {
+public class Db2StreamingChangeEventSource implements StreamingChangeEventSource<Db2Partition, Db2OffsetContext> {
 
     private static final int COL_COMMIT_LSN = 2;
     private static final int COL_ROW_LSN = 3;
@@ -97,7 +97,8 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, Db2OffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, Db2Partition partition, Db2OffsetContext offsetContext)
+            throws InterruptedException {
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
         final Queue<Db2ChangeTable> schemaChangeCheckpoints = new PriorityQueue<>((x, y) -> x.getStopLsn().compareTo(y.getStopLsn()));
         try {

--- a/src/test/java/io/debezium/connector/db2/Db2PartitionTest.java
+++ b/src/test/java/io/debezium/connector/db2/Db2PartitionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2;
+
+import io.debezium.connector.common.AbstractPartitionTest;
+
+public class Db2PartitionTest extends AbstractPartitionTest<Db2Partition> {
+
+    @Override
+    protected Db2Partition createPartition1() {
+        return new Db2Partition("server1");
+    }
+
+    @Override
+    protected Db2Partition createPartition2() {
+        return new Db2Partition("server2");
+    }
+}


### PR DESCRIPTION
See [DBZ-2975](https://issues.redhat.com/browse/DBZ-2975).

This PR complements https://github.com/debezium/debezium/pull/2487.

**TODO**:
- [x] Run unit and integration tests locally.