### PR TITLE
DBZ-3577 Read-only incremental snapshots refactoring

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2ChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ChangeEventSourceFactory.java
@@ -66,6 +66,7 @@ public class Db2ChangeEventSourceFactory implements ChangeEventSourceFactory<Db2
         final SignalBasedIncrementalSnapshotChangeEventSource<TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<TableId>(
                 configuration,
                 dataConnection,
+                dispatcher,
                 schema,
                 clock,
                 snapshotProgressListener,

--- a/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
+++ b/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.relational.TableId;
@@ -61,7 +62,7 @@ public class Db2OffsetContext implements OffsetContext {
     }
 
     public Db2OffsetContext(Db2ConnectorConfig connectorConfig, TxLogPosition position, boolean snapshot, boolean snapshotCompleted) {
-        this(connectorConfig, position, snapshot, snapshotCompleted, 1, new TransactionContext(), new IncrementalSnapshotContext<>(false));
+        this(connectorConfig, position, snapshot, snapshotCompleted, 1, new TransactionContext(), new SignalBasedIncrementalSnapshotContext<>(false));
     }
 
     @Override
@@ -162,7 +163,7 @@ public class Db2OffsetContext implements OffsetContext {
             }
 
             return new Db2OffsetContext(connectorConfig, TxLogPosition.valueOf(commitLsn, changeLsn), snapshot, snapshotCompleted, eventSerialNo,
-                    TransactionContext.load(offset), IncrementalSnapshotContext.load(offset, false, TableId.class));
+                    TransactionContext.load(offset), SignalBasedIncrementalSnapshotContext.load(offset, false));
         }
     }
 


### PR DESCRIPTION
The refactoring for MySQL read-only incremental snapshots (https://issues.redhat.com/browse/DBZ-3577) is touching some common parts 

Related  to https://github.com/debezium/debezium/pull/2430