### PR TITLE
jdbc conection test sql syntax fix

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2Connector.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connector.java
@@ -77,7 +77,7 @@ public class Db2Connector extends RelationalBaseSourceConnector {
         try (Db2Connection connection = new Db2Connection(connectorConfig.getJdbcConfig())) {
             try {
                 connection.connect();
-                connection.execute("SELECT 1 FROM sysibm.sysdummy1;");
+                connection.execute("SELECT 1 FROM sysibm.sysdummy1");
                 LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(), connection.username());
             }
             catch (SQLException e) {


### PR DESCRIPTION
Hi, not sure what proper procedures are to report/submit issues or fixes so please feel free to correct or point for more info.
We have been running into below error:
ERROR Failed testing connection for jdbc:db2://db2server:50000/test with user 'db2inst1' (io.debezium.connector.db2.Db2Connector) 
com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-104, SQLSTATE=42601, SQLERRMC=;;ROM sysibm.sysdummy1;END-OF-STATEMENT, DRIVER=[3.72.54]

Have attempted DB versions 10.5 and 11.1, Debezium plugin versions 1.6, 1.7 and 1.8, and also numerous jdbc driver versions. All returned same error.

Appears to be resolved by removing extra semicolon.