### PR TITLE
DBZ-4727 Use smaller chunk size in tests

### DIFF
--- a/src/test/java/io/debezium/connector/db2/IncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/db2/IncrementalSnapshotIT.java
@@ -109,7 +109,8 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
     protected Builder config() {
         return TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(Db2ConnectorConfig.SIGNAL_DATA_COLLECTION, "DB2INST1.DEBEZIUM_SIGNAL");
+                .with(Db2ConnectorConfig.SIGNAL_DATA_COLLECTION, "DB2INST1.DEBEZIUM_SIGNAL")
+                .with(Db2ConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250);
     }
 
     @Override


### PR DESCRIPTION
Some incremental snapshot tests may require smaller chunk size to do
more iterations while reading chunks. Lower the chunk size to 250.
This is same size SQL server is using. Other tests use chunk size of 10,
however, tests on DB2 are slow and this would make tests even more slow,
so 250 seems like a good compromise.