### PR TITLE
DBZ-5429: Add INITIAL_ONLY flag to snapshot mode

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -46,19 +46,26 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         /**
          * Perform a snapshot of data and schema upon initial startup of a connector.
          */
-        INITIAL("initial", true),
+        INITIAL("initial", true, true),
+
+        /**
+         * Perform a snapshot of data and schema upon initial startup of a connector and stop after initial consistent snapshot.
+         */
+        INITIAL_ONLY("initial_only", true, false),
 
         /**
          * Perform a snapshot of the schema but no data upon initial startup of a connector.
          */
-        SCHEMA_ONLY("schema_only", false);
+        SCHEMA_ONLY("schema_only", false, true);
 
         private final String value;
         private final boolean includeData;
+        private final boolean shouldStream;
 
-        private SnapshotMode(String value, boolean includeData) {
+        private SnapshotMode(String value, boolean includeData, boolean shouldStream) {
             this.value = value;
             this.includeData = includeData;
+            this.shouldStream = shouldStream;
         }
 
         @Override
@@ -72,6 +79,13 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
          */
         public boolean includeData() {
             return includeData;
+        }
+
+        /**
+         * Whether the snapshot mode is followed by streaming.
+         */
+        public boolean shouldStream() {
+            return shouldStream;
         }
 
         /**

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -101,6 +101,11 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
     @Override
     public void execute(ChangeEventSourceContext context, Db2Partition partition, Db2OffsetContext offsetContext)
             throws InterruptedException {
+        if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            LOGGER.info("Streaming is not enabled in current configuration");
+            return;
+        }
+
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
         final Queue<Db2ChangeTable> schemaChangeCheckpoints = new PriorityQueue<>((x, y) -> x.getStopLsn().compareTo(y.getStopLsn()));
         try {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5429

Added INITIAL_ONLY snapshot mode to Db2 connector. 

The documentation PR can be found here: https://github.com/debezium/debezium/pull/3733