### PR TITLE
DBZ-5919: Refactor ComputePartition SMT to be more extensible on source info parsing

### DIFF
--- a/src/main/java/io/debezium/connector/db2/converters/Db2CloudEventsProvider.java
+++ b/src/main/java/io/debezium/connector/db2/converters/Db2CloudEventsProvider.java
@@ -5,10 +5,7 @@
  */
 package io.debezium.connector.db2.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
-import io.debezium.connector.db2.Module;
+import io.debezium.connector.db2.transforms.Db2AbstractRecordParserProvider;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -19,17 +16,7 @@ import io.debezium.converters.spi.SerializerType;
  *
  * @author Chris Cranford
  */
-public class Db2CloudEventsProvider implements CloudEventsProvider {
-    @Override
-    public String getName() {
-        return Module.name();
-    }
-
-    @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new Db2RecordParser(schema, record);
-    }
-
+public class Db2CloudEventsProvider extends Db2AbstractRecordParserProvider implements CloudEventsProvider {
     @Override
     public CloudEventsMaker createMaker(RecordParser parser, SerializerType contentType, String dataSchemaUriBase) {
         return new Db2CloudEventsMaker(parser, contentType, dataSchemaUriBase);

--- a/src/main/java/io/debezium/connector/db2/converters/Db2RecordParser.java
+++ b/src/main/java/io/debezium/connector/db2/converters/Db2RecordParser.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2.converters;
 
 import java.util.Set;
 
+import io.debezium.connector.AbstractSourceInfo;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
@@ -27,7 +28,9 @@ public class Db2RecordParser extends RecordParser {
 
     static final Set<String> DB2_SOURCE_FIELD = Collect.unmodifiableSet(
             CHANGE_LSN_KEY,
-            COMMIT_LSN_KEY);
+            COMMIT_LSN_KEY,
+            AbstractSourceInfo.SCHEMA_NAME_KEY,
+            AbstractSourceInfo.TABLE_NAME_KEY);
 
     public Db2RecordParser(Schema schema, Struct record) {
         super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);

--- a/src/main/java/io/debezium/connector/db2/transforms/Db2AbstractRecordParserProvider.java
+++ b/src/main/java/io/debezium/connector/db2/transforms/Db2AbstractRecordParserProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2.transforms;
+
+import io.debezium.connector.db2.Module;
+import io.debezium.connector.db2.converters.Db2RecordParser;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.transforms.spi.RecordParserProvider;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+public abstract class Db2AbstractRecordParserProvider implements RecordParserProvider {
+
+    @Override
+    public String getName() {
+        return Module.name();
+    }
+
+    @Override
+    public RecordParser createParser(Schema schema, Struct record) {
+        return new Db2RecordParser(schema, record);
+    }
+}

--- a/src/main/java/io/debezium/connector/db2/transforms/Db2QualifiedTableNameResolver.java
+++ b/src/main/java/io/debezium/connector/db2/transforms/Db2QualifiedTableNameResolver.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2.transforms;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.transforms.spi.QualifiedTableNameResolver;
+
+public class Db2QualifiedTableNameResolver extends Db2AbstractRecordParserProvider implements QualifiedTableNameResolver {
+    public static final String FULLY_QUALIFIED_NAME_FORMAT = "%s.%s";
+
+    @Override
+    public String resolve(RecordParser recordParser) {
+        return String.format(FULLY_QUALIFIED_NAME_FORMAT,
+                recordParser.getMetadata(AbstractSourceInfo.SCHEMA_NAME_KEY),
+                recordParser.getMetadata(AbstractSourceInfo.TABLE_NAME_KEY));
+    }
+}

--- a/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.db2.transforms.Db2QualifiedTableNameResolver

--- a/src/test/java/io/debezium/connector/db2/transforms/ComputePartitionTest.java
+++ b/src/test/java/io/debezium/connector/db2/transforms/ComputePartitionTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2.transforms;
+
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.debezium.data.Envelope.Operation.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ComputePartitionTest {
+
+    public static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
+            .name("server-1.inventory.products.Value")
+            .field("id", Schema.INT64_SCHEMA)
+            .field("price", Schema.FLOAT32_SCHEMA)
+            .field("product", Schema.STRING_SCHEMA)
+            .build();
+
+    private final ComputePartition<SourceRecord> computePartitionTransformation = new ComputePartition<>();
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnCreateAndUpdateEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnDeleteEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "APPLE"), DELETE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void partitionNotComputedOnTruncateEvent() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "APPLE"), TRUNCATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isEqualTo(eventRecord.kafkaPartition());
+    }
+
+    @Test
+    public void rowWithSameConfiguredFieldValueWillHaveTheSamePartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("db2", "db2", "inventory", "products", productRow(2L, 2.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isZero();
+        assertThat(transformed2.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void rowWithDifferentConfiguredFieldValueWillHaveDifferentPartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("db2", "db2", "inventory", "products", productRow(3L, 0.95F, "BANANA"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isNotEqualTo(transformed2.kafkaPartition());
+    }
+
+    @Test
+    public void notConsistentConfigurationSizeWillThrowConnectionException() {
+
+        assertThatThrownBy(() -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different number of table defined");
+    }
+
+    @Test
+    public void notConsistentConfigurationWillThrowConnectionException() {
+
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "prod:2,purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different tables defined");
+    }
+
+    @Test
+    public void negativeHashCodeValueWillBeCorrectlyManaged() {
+
+        configureTransformation("inventory.products:product", "inventory.products:3");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("db2", "db2", "inventory", "products", productRow(1L, 1.0F, "orange"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        assertThat(transformed1.kafkaPartition()).isEqualTo(1);
+    }
+
+    @Test
+    public void zeroAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:0,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    @Test
+    public void negativeAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:-3,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    private SourceRecord buildSourceRecord(String connector, String db, String schema, String tableName, Struct row, Envelope.Operation operation) {
+
+        String dataCollectionFieldName = "mongodb".equals(connector) ? "collection" : "table";
+
+        SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
+                .name("source")
+                .field("connector", Schema.STRING_SCHEMA)
+                .field("db", Schema.STRING_SCHEMA)
+                .field(dataCollectionFieldName, Schema.STRING_SCHEMA);
+
+        if (schema != null) {
+            sourceSchemaBuilder.field("schema", Schema.STRING_SCHEMA);
+        }
+
+        Schema sourceSchema = sourceSchemaBuilder.build();
+
+        Envelope createEnvelope = Envelope.defineSchema()
+                .withName("server-1.inventory.product.Envelope")
+                .withRecord(VALUE_SCHEMA)
+                .withSource(sourceSchema)
+                .build();
+
+        Struct source = new Struct(sourceSchema);
+        source.put("connector", connector);
+        source.put("db", db);
+        source.put(dataCollectionFieldName, tableName);
+        if (schema != null) {
+            source.put("schema", schema);
+        }
+
+        Struct payload = createEnvelope.create(row, source, Instant.now());
+
+        switch (operation) {
+            case CREATE:
+            case UPDATE:
+            case READ:
+                payload = createEnvelope.create(row, source, Instant.now());
+                break;
+            case DELETE:
+                payload = createEnvelope.delete(row, source, Instant.now());
+                break;
+            case TRUNCATE:
+                payload = createEnvelope.truncate(source, Instant.now());
+                break;
+        }
+
+        return new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "prefix.inventory.products",
+                createEnvelope.schema(), payload);
+    }
+
+    private void configureTransformation(String tableFieldMapping, String tablePartitionNumMapping) {
+        computePartitionTransformation.configure(Map.of(
+                "partition.data-collections.field.mappings", tableFieldMapping,
+                "partition.data-collections.partition.num.mappings", tablePartitionNumMapping));
+    }
+
+    private Struct productRow(long id, float price, String name) {
+        return new Struct(VALUE_SCHEMA)
+                .put("id", id)
+                .put("price", price)
+                .put("product", name);
+    }
+}

--- a/src/test/resources/META-INF.services/io.debezium.converters.spi.CloudEventsProvider
+++ b/src/test/resources/META-INF.services/io.debezium.converters.spi.CloudEventsProvider
@@ -1,0 +1,1 @@
+io.debezium.connector.db2.converters.Db2CloudEventsProvider

--- a/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.db2.transforms.Db2QualifiedTableNameResolver


### PR DESCRIPTION
Implement QualifiedTableNameResolver for ComputePartition SMT

Depends on [#DBZ-5919](https://github.com/debezium/debezium/pull/4361)