### PR TITLE
DBZ-5252 Fix intermittent failure

### DIFF
--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -272,7 +272,9 @@ public class Db2ConnectorIT extends AbstractConnectorTest {
 
         TestHelper.refreshAndWait(connection);
 
-        final SourceRecords records1 = consumeRecordsByTopic(2);
+        // Ignore all initial create records - with original ID
+        final var records1 = consumeRecordsButSkipUntil(2,
+                (key, value) -> (value == null) || !value.getString("op").equals("c") || key.getInt32("ID") != 1);
         stopConnector();
 
         start(Db2Connector.class, config);


### PR DESCRIPTION
Depending on timing a record inserted during connector start can be delivered both in snapshot ans streaming. For test stability it is better to initialize database before conector starts.