### PR TITLE
DBZ-5071 Correctly handle NULL values in incremental snapshots

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -417,6 +417,13 @@ public class Db2Connection extends JdbcConnection {
     }
 
     @Override
+    public Optional<Boolean> nullsSortLast() {
+        // "The null value is higher than all other values"
+        // https://www.ibm.com/docs/en/db2/11.5?topic=subselect-order-by-clause
+        return Optional.of(true);
+    }
+
+    @Override
     public String quotedTableIdString(TableId tableId) {
         StringBuilder quoted = new StringBuilder();
         if (tableId.schema() != null && !tableId.schema().isEmpty()) {

--- a/src/test/java/io/debezium/connector/db2/IncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/db2/IncrementalSnapshotIT.java
@@ -21,6 +21,7 @@ import io.debezium.junit.ConditionalFail;
 import io.debezium.junit.Flaky;
 import io.debezium.junit.SkipTestRule;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.util.Testing;
 
@@ -39,15 +40,18 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
         TestHelper.disableDbCdc(connection);
         TestHelper.disableTableCdc(connection, "A");
         TestHelper.disableTableCdc(connection, "B");
+        TestHelper.disableTableCdc(connection, "A42");
         TestHelper.disableTableCdc(connection, "DEBEZIUM_SIGNAL");
         connection.execute("DELETE FROM ASNCDC.IBMSNAP_REGISTER");
         connection.execute(
                 "DROP TABLE IF EXISTS a",
                 "DROP TABLE IF EXISTS b",
+                "DROP TABLE IF EXISTS a42",
                 "DROP TABLE IF EXISTS debezium_signal");
         connection.execute(
                 "CREATE TABLE a (pk int not null, aa int, primary key (pk))",
                 "CREATE TABLE b (pk int not null, aa int, primary key (pk))",
+                "CREATE TABLE a42 (pk1 int, pk2 int, pk3 int, pk4 int, aa int)",
                 "CREATE TABLE debezium_signal (id varchar(64), type varchar(32), data varchar(2048))");
 
         TestHelper.enableDbCdc(connection);
@@ -65,11 +69,13 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
             TestHelper.disableDbCdc(connection);
             TestHelper.disableTableCdc(connection, "A");
             TestHelper.disableTableCdc(connection, "B");
+            TestHelper.disableTableCdc(connection, "A42");
             TestHelper.disableTableCdc(connection, "DEBEZIUM_SIGNAL");
             connection.rollback();
             connection.execute(
                     "DROP TABLE IF EXISTS a",
                     "DROP TABLE IF EXISTS b",
+                    "DROP TABLE IF EXISTS a42",
                     "DROP TABLE IF EXISTS debezium_signal");
             connection.execute("DELETE FROM ASNCDC.IBMSNAP_REGISTER");
             connection.execute("DELETE FROM ASNCDC.IBMQREP_COLVERSION");
@@ -89,6 +95,12 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
         super.populateTables();
         TestHelper.enableTableCdc(connection, "A");
         TestHelper.enableTableCdc(connection, "B");
+    }
+
+    @Override
+    protected void populate4PkTable(JdbcConnection connection, String tableName) throws SQLException {
+        super.populate4PkTable(connection, tableName);
+        TestHelper.enableTableCdc((Db2Connection) connection, tableName.replaceAll(".*\\.", ""));
     }
 
     @Override
@@ -112,6 +124,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
     }
 
     @Override
+    protected String noPKTopicName() {
+        return "testdb.DB2INST1.A42";
+    }
+
+    @Override
     protected String tableName() {
         return "DB2INST1.A";
     }
@@ -122,12 +139,22 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
     }
 
     @Override
+    protected String noPKTableName() {
+        return "DB2INST1.A42";
+    }
+
+    @Override
     protected String signalTableName() {
         return "DEBEZIUM_SIGNAL";
     }
 
     protected String getSignalTypeFieldName() {
         return "TYPE";
+    }
+
+    @Override
+    protected String returnedIdentifierName(String queriedID) {
+        return queriedID.toUpperCase();
     }
 
     protected void sendAdHocSnapshotSignal() throws SQLException {
@@ -143,7 +170,8 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
         return TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(Db2ConnectorConfig.SIGNAL_DATA_COLLECTION, "DB2INST1.DEBEZIUM_SIGNAL")
-                .with(Db2ConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250);
+                .with(Db2ConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250)
+                .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, "DB2INST1.A42:pk1,pk2,pk3,pk4");
     }
 
     @Override
@@ -159,7 +187,8 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Db2Co
                 .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .with(Db2ConnectorConfig.SIGNAL_DATA_COLLECTION, "DB2INST1.DEBEZIUM_SIGNAL")
                 .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
-                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedDdl);
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedDdl)
+                .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, "DB2INST1.A42:pk1,pk2,pk3,pk4");
     }
 
     @Override


### PR DESCRIPTION
This makes changes in the Db2 connector for the corresponding commit in the main Debezium project.  The main thing we have to do is override the nullsSortLast function in Db2Connection to define how NULLs sort in Db2. We also have to update the test suite, since the base test suite now includes additional tests for working with keys that are nullable.

Related pull request: https://github.com/debezium/debezium/pull/5158