### PR TITLE
Fix Db2 Test Failures

### DIFF
--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -58,6 +58,8 @@ public class Db2ConnectorIT extends AbstractConnectorTest {
 
     @Before
     public void before() throws SQLException {
+        TestHelper.dropAllTables();
+
         connection = TestHelper.testConnection();
         connection.execute("DELETE FROM ASNCDC.IBMSNAP_REGISTER");
         connection.execute(

--- a/src/test/java/io/debezium/connector/db2/Db2OnlineDefaultValueIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2OnlineDefaultValueIT.java
@@ -5,8 +5,15 @@
  */
 package io.debezium.connector.db2;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
 import io.debezium.config.Configuration;
 import io.debezium.connector.db2.util.TestHelper;
+import io.debezium.doc.FixFor;
+import io.debezium.junit.ConditionalFail;
+import io.debezium.junit.Flaky;
 import io.debezium.relational.TableId;
 
 /**
@@ -15,6 +22,17 @@ import io.debezium.relational.TableId;
  * @author Chris Cranford
  */
 public class Db2OnlineDefaultValueIT extends AbstractDb2DefaultValueIT {
+
+    @Rule
+    public TestRule conditionalFail = new ConditionalFail();
+
+    @Test
+    @FixFor("DBZ-4990")
+    @Flaky("DBZ-6048")
+    public void shouldHandleDateTimeDefaultTypes() throws Exception {
+        super.shouldHandleDateTimeDefaultTypes();
+    }
+
     @Override
     protected void performSchemaChange(Configuration config, Db2Connection connection, String alterStatement) throws Exception {
         final TableId tableId = TableId.parse("DB2INST1.DV_TEST");

--- a/src/test/java/io/debezium/connector/db2/Db2ReselectColumnsProcessorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ReselectColumnsProcessorIT.java
@@ -59,6 +59,7 @@ public class Db2ReselectColumnsProcessorIT extends AbstractReselectProcessorTest
     @Override
     protected Configuration.Builder getConfigurationBuilder() {
         return TestHelper.defaultConfig()
+                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, "DB2INST1\\.DBZ4321")
                 .with(Db2ConnectorConfig.CUSTOM_POST_PROCESSORS, "reselector")
                 .with("reselector.type", ReselectColumnsPostProcessor.class.getName());
     }

--- a/src/test/java/io/debezium/connector/db2/util/TestHelper.java
+++ b/src/test/java/io/debezium/connector/db2/util/TestHelper.java
@@ -272,4 +272,19 @@ public class TestHelper {
 
         }
     }
+
+    public static void dropAllTables() throws SQLException {
+        try (Db2Connection connection = testConnection()) {
+            LOGGER.info("Attempting to drop all tables (if exists)");
+            connection.query("SELECT TABNAME FROM syscat.tables WHERE TABSCHEMA = 'DB2INST1'", rs -> {
+                while (rs.next()) {
+                    final String tableName = rs.getString(1);
+                    LOGGER.info("Disabling CDC for table {}", tableName);
+                    disableTableCdc(connection, "DB2INST1", tableName);
+                    LOGGER.warn("Dropping table {}", tableName);
+                    connection.execute("DROP TABLE IF EXISTS " + tableName);
+                }
+            });
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses three concerns:

- [x] Marks `Db2OnlineDefaultValueIT#shouldHandleDateTimeDefaultTypes` as `@Flaky` (see DBZ-6048).
- [x] Guards `Db2ReselectColumnsProcessorIT` with a `table.include.list` to avoid taint from other test failures (see DBZ-7471).
- [x] Sanitize each `Db2ConnectorIT` test case to handle potential taint issues 