### PR TITLE
Changes made for supporting Z/OS

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2ChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ChangeRecordEmitter.java
@@ -21,6 +21,7 @@ public class Db2ChangeRecordEmitter extends RelationalChangeRecordEmitter<Db2Par
     public static final int OP_INSERT = 2;
     public static final int OP_UPDATE_BEFORE = 3;
     public static final int OP_UPDATE_AFTER = 4;
+    public static final int OP_UPDATE_SINGLE = 5;
 
     private final int operation;
     private final Object[] data;
@@ -44,6 +45,9 @@ public class Db2ChangeRecordEmitter extends RelationalChangeRecordEmitter<Db2Par
             return Operation.CREATE;
         }
         else if (operation == OP_UPDATE_BEFORE) {
+            return Operation.UPDATE;
+        }
+        else if (operation == OP_UPDATE_SINGLE) {
             return Operation.UPDATE;
         }
         throw new IllegalArgumentException("Received event of unexpected command type: " + operation);

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -387,6 +387,18 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         }
     }
 
+    /**
+     * Define if the connector, running in Z/OS mode, should ignore the stopLsn (IBMSNAP_REGISTER.CD_OLD_SYNCPOINT) during polling
+     */
+    public static final Field Z_STOP_LSN_IGNORE_IND = Field.create("z.stop.lsn.ignore.ind")
+            .withDisplayName("Z/OS stopLSN ignore indicator")
+            .withDefault(false)
+            .withType(Type.BOOLEAN)
+            .withDescription("If true, causes the connector to ignore the stopLsn value from the " +
+                    "IBMSNAP_REGISTER.CD_OLD_SYNCPOINT column when polling.  A" +
+                    "pply this if events are getting dropped dure to the stopLSN being " +
+                    "smaller than the current range of LSNs.  Only applies to Z_OS");
+
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
 
@@ -517,6 +529,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     private final SnapshotLockingMode snapshotLockingMode;
 
     private final Db2Platform db2Platform;
+    private final Boolean zStopLSNIgnoreInd;
     private final String cdcChangeTablesSchema;
     private final String cdcControlSchema;
 
@@ -536,6 +549,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
 
         this.db2Platform = Db2Platform.parse(config.getString(DB2_PLATFORM), DB2_PLATFORM.defaultValueAsString());
+        this.zStopLSNIgnoreInd = config.getBoolean(Z_STOP_LSN_IGNORE_IND);
         this.cdcChangeTablesSchema = config.getString(CDC_CHANGE_TABLES_SCHEMA);
         this.cdcControlSchema = config.getString(CDC_CONTROL_SCHEMA);
     }
@@ -558,6 +572,10 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     public Db2Platform getDb2Platform() {
         return db2Platform;
+    }
+
+    public Boolean getZStopLSNIgnoreInd() {
+        return zStopLSNIgnoreInd;
     }
 
     public String getCdcChangeTablesSchema() {

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -31,6 +31,7 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 " order by IBMSNAP_COMMITSEQ, IBMSNAP_INTENTSEQ), " +
                 " tmp2 AS (SELECT " +
                 " CASE " +
+                " WHEN cdc.IBMSNAP_OPERATION = 'U' THEN 5" +
                 " WHEN cdc.IBMSNAP_OPERATION = 'D' AND cdc2.IBMSNAP_OPERATION ='I' THEN 3 " +
                 " WHEN cdc.IBMSNAP_OPERATION = 'I' AND cdc2.IBMSNAP_OPERATION ='D' THEN 4 " +
                 " WHEN cdc.IBMSNAP_OPERATION = 'D' THEN 1 " +


### PR DESCRIPTION
Changes made for supporting Z/OS, specifically a change to how the updates are handled with a single "U" record instead of a "D" then "I" like in LUW.  Also a configuration option to allow the nulling of the stopLSN, which is always null in LUW, making the behavior similar to how it works for LUW.