### PR TITLE
DBZ-9024 Fix Debezium Crash on Single Row U Updates

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -255,21 +255,15 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                             if (operation == Db2ChangeRecordEmitter.OP_UPDATE_BEFORE) {
                                 dataNext = tableWithSmallestLsn.getData();
                             }
-                            // Specifically handle that updates in Z are single-record after state logs
+                            // Specifically handle that updates that DB2 is showing as single "U" events
                             else if (operation == Db2ChangeRecordEmitter.OP_UPDATE_SINGLE) {
-                                if (connectorConfig.getDb2Platform() == Db2ConnectorConfig.Db2Platform.Z) {
-                                    dataNext = tableWithSmallestLsn.getData();
-                                    data = null;
-                                }
-                                else {
-                                    LOGGER.warn("Unexpected event type {} for table {}. The event will not be properly initialized.", operation, tableId);
-                                }
+                                dataNext = tableWithSmallestLsn.getData();
+                                data = null;
                             }
 
                             offsetContext.setChangePosition(tableWithSmallestLsn.getChangePosition(), eventCount);
                             offsetContext.event(tableWithSmallestLsn.getChangeTable().getSourceTableId(),
                                     metadataConnection.timestampOfLsn(tableWithSmallestLsn.getChangePosition().getCommitLsn()));
-
                             dispatcher
                                     .dispatchDataChangeEvent(
                                             partition,

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -26,6 +26,7 @@ public class LuwPlatform implements Db2PlatformAdapter {
 
         this.getAllChangesForTable = "SELECT "
                 + "CASE "
+                + "WHEN IBMSNAP_OPERATION = 'U' THEN 5 "
                 + "WHEN IBMSNAP_OPERATION = 'D' AND (LEAD(cdc.IBMSNAP_OPERATION,1,'X') OVER (PARTITION BY cdc.IBMSNAP_COMMITSEQ ORDER BY cdc.IBMSNAP_INTENTSEQ)) ='I' THEN 3 "
                 + "WHEN IBMSNAP_OPERATION = 'I' AND (LAG(cdc.IBMSNAP_OPERATION,1,'X') OVER (PARTITION BY cdc.IBMSNAP_COMMITSEQ ORDER BY cdc.IBMSNAP_INTENTSEQ)) ='D' THEN 4 "
                 + "WHEN IBMSNAP_OPERATION = 'D' THEN 1 "

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -11,6 +11,8 @@ import static io.debezium.connector.db2.util.TestHelper.TYPE_SCALE_PARAMETER_KEY
 import static io.debezium.data.Envelope.FieldName.AFTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.sql.SQLException;
@@ -156,6 +158,108 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
             assertRecord((Struct) deleteValue.get("before"), expectedDeleteRow);
             assertNull(deleteValue.get("after"));
         }
+
+        stopConnector();
+    }
+
+    @Test
+    public void updateAsSingleCDCURecord() throws Exception {
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .build();
+
+        start(Db2Connector.class, config);
+        assertConnectorIsRunning();
+
+        TestHelper.enableDbCdc(connection);
+        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A', CHG_UPD_TO_DEL_INS = 'N' WHERE SOURCE_OWNER = 'DB2INST1'");
+
+        TestHelper.refreshAndWait(connection);
+
+        connection.setAutoCommit(false);
+        consumeRecordsByTopic(1); // Bypass the snapshot R Record
+        connection.execute(
+                "UPDATE tablea SET cola='b' WHERE id=1");
+        connection.commit();
+
+        TestHelper.refreshAndWait(connection);
+
+        final SourceRecords records = consumeRecordsByTopic(1);
+        final List<SourceRecord> tableA = records.recordsForTopic("testdb.DB2INST1.TABLEA");
+        assertThat(tableA).hasSize(1);
+
+        final List<SchemaAndValueField> expectedUpdateKeyA = Arrays.asList(
+                new SchemaAndValueField("ID", Schema.INT32_SCHEMA, 1));
+        final List<SchemaAndValueField> expectedUpdateRowA = Arrays.asList(
+                new SchemaAndValueField("ID", Schema.INT32_SCHEMA, 1),
+                new SchemaAndValueField("COLA", Schema.OPTIONAL_STRING_SCHEMA, "b"));
+
+        final SourceRecord updateRecordA = tableA.get(0);
+        logger.info("updateAsSingleCDCURecord - Update Record: {}", updateRecordA);
+
+        final Struct updateKeyA = (Struct) updateRecordA.key();
+        final Struct updateValueA = (Struct) updateRecordA.value();
+        assertRecord(updateValueA.getStruct("after"), expectedUpdateRowA);
+        assertEquals(updateValueA.getString("op"), "u");
+        assertRecord(updateKeyA, expectedUpdateKeyA);
+        assertNull(updateValueA.get("before"));
+
+        stopConnector();
+    }
+
+    @Test
+    public void updateAsDoubleCDCDIRecords() throws Exception {
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .build();
+
+        start(Db2Connector.class, config);
+        assertConnectorIsRunning();
+
+        TestHelper.enableDbCdc(connection);
+        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A', CHG_UPD_TO_DEL_INS = 'Y' WHERE SOURCE_OWNER = 'DB2INST1'");
+
+        TestHelper.refreshAndWait(connection);
+
+        connection.setAutoCommit(false);
+        consumeRecordsByTopic(1); // Bypass the snapshot R Record
+        connection.execute(
+                "UPDATE tablea SET cola='b' WHERE id=1");
+        connection.commit();
+
+        TestHelper.refreshAndWait(connection);
+
+        final SourceRecords records = consumeRecordsByTopic(1);
+        final List<SourceRecord> tableA = records.recordsForTopic("testdb.DB2INST1.TABLEA");
+        assertThat(tableA).hasSize(1);
+
+        final List<SchemaAndValueField> expectedUpdateKeyA = Arrays.asList(
+                new SchemaAndValueField("ID", Schema.INT32_SCHEMA, 1));
+
+        final List<SchemaAndValueField> expectedBeforeUpdateRowA = Arrays.asList(
+                new SchemaAndValueField("ID", Schema.INT32_SCHEMA, 1),
+                new SchemaAndValueField("COLA", Schema.OPTIONAL_STRING_SCHEMA, "a"));
+
+        final List<SchemaAndValueField> expectedUpdateRowA = Arrays.asList(
+                new SchemaAndValueField("ID", Schema.INT32_SCHEMA, 1),
+                new SchemaAndValueField("COLA", Schema.OPTIONAL_STRING_SCHEMA, "b"));
+
+        final SourceRecord updateRecordA = tableA.get(0);
+        logger.info("updateAsDoubleCDCDIRecords - Update Record: {}", updateRecordA);
+
+        final Struct updateKeyA = (Struct) updateRecordA.key();
+        final Struct updateValueA = (Struct) updateRecordA.value();
+
+        assertRecord(updateKeyA, expectedUpdateKeyA);
+        assertRecord(updateValueA.getStruct("before"), expectedBeforeUpdateRowA);
+        assertRecord(updateValueA.getStruct("after"), expectedUpdateRowA);
+
+        assertEquals(updateValueA.getString("op"), "u");
+
+        assertNotNull(updateValueA.get("before"));
+        assertNotNull(updateValueA.get("after"));
 
         stopConnector();
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9024

What behavior do you expect?
When db2 replication is set to use a single update row (from IBMSNAP_REGISTER CHG_UPD_TO_DEL_INS = N), an update should not crash the connector task, but should produce an update event, but not have a before record.