### PR TITLE
Remove un-used embedded kafka dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,6 @@
             </dependency>
             <dependency>
                 <groupId>io.debezium</groupId>
-                <artifactId>debezium-embedded</artifactId>
-                <version>${version.debezium}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.debezium</groupId>
                 <artifactId>debezium-storage-kafka</artifactId>
                 <version>${version.debezium}</version>
             </dependency>
@@ -154,13 +149,6 @@
             <dependency>
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-core</artifactId>
-                <version>${version.debezium}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-embedded</artifactId>
                 <version>${version.debezium}</version>
                 <type>test-jar</type>
                 <scope>test</scope>


### PR DESCRIPTION
This PR removes unused dependencies and its follow-up for the core PR on [1]

[1] - https://github.com/debezium/debezium/pull/6756