### PR TITLE
DBZ-9512 Add strimzi-test-container dependency to make core repo pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR adds `strimzi-test-container` dependency to the DB2 connector. That should solve the current problem in the Debezium core repository, which is:
```java
Error:  Errors: 
Error:    IncrementalSnapshotIT.initializationError » NoClassDefFound io/strimzi/test/container/StrimziKafkaCluster
[INFO] 
Error:  Tests run: 56, Failures: 0, Errors: 1, Skipped: 3
```