### PR TITLE
debezium/dbz#1935 Fix intermittent TransactionMetadataIT by waiting f…

### DIFF
--- a/src/test/java/io/debezium/connector/db2/Db2ChunkedSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ChunkedSnapshotIT.java
@@ -46,6 +46,7 @@ public class Db2ChunkedSnapshotIT extends AbstractChunkedSnapshotTest<Db2Connect
     @AfterEach
     public void afterEach() throws Exception {
         if (connection != null) {
+            TestHelper.dropAllTables();
             TestHelper.disableDbCdc(connection);
             connection.close();
         }

--- a/src/test/java/io/debezium/connector/db2/TransactionMetadataIT.java
+++ b/src/test/java/io/debezium/connector/db2/TransactionMetadataIT.java
@@ -67,6 +67,7 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
         final Configuration config = TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .with(Db2ConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, "DB2INST1\\.TABLEA,DB2INST1\\.TABLEB")
                 .build();
 
         start(Db2Connector.class, config);

--- a/src/test/java/io/debezium/connector/db2/TransactionMetadataIT.java
+++ b/src/test/java/io/debezium/connector/db2/TransactionMetadataIT.java
@@ -74,6 +74,7 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
 
         // Wait for snapshot completion
         consumeRecordsByTopic(1);
+        waitForStreamingRunning("db2_server", TestHelper.TEST_DATABASE);
 
         TestHelper.enableDbCdc(connection);
         connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A' WHERE SOURCE_OWNER = 'DB2INST1'");


### PR DESCRIPTION
Fixes debezium/dbz#1935

This PR fixes an intermittent failure in `TransactionMetadataIT.transactionMetadata`.

After `consumeRecordsByTopic(1)` completes, the test immediately enables CDC and executes DML operations. However, the connector may still be transitioning from snapshot mode to streaming mode at that time.

Because of this race condition, CDC log entries for `TABLEA` can occasionally be missed before streaming starts, causing:

```text
AssertionError: Expecting actual not to be null
```

The fix adds:

```java
waitForStreamingRunning("db2_server", TestHelper.TEST_DATABASE);
```

after snapshot completion to ensure the connector has fully entered streaming mode before CDC is enabled and inserts are executed.

Other DB2 integration tests already use the same synchronization step before performing streaming-dependent operations.
