### PR TITLE
debezium/dbz#1843 - Enable DB2 Support for Change Table Prune

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -6,7 +6,13 @@
 
 package io.debezium.connector.db2;
 
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -453,28 +453,27 @@ public class Db2Connection extends JdbcConnection {
              * IN P_TARGET_SERVER VARCHAR(18),
              * OUT P_UPDATED_COUNT INT
              */
-            final CallableStatement cs = connection().prepareCall(
+            try (final CallableStatement cs = connection().prepareCall(
                     platform.getUpdatePruneSetProcedureCall(
-                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()));
-
-            cs.setBytes("P_SYNCHPOINT", synchPointLSN.getBinary());
-            cs.setTimestamp("P_SYNCHTIME", Timestamp.from(synchInstant));
-            cs.setString("P_APPLY_QUAL", applyQual);
-            cs.setString("P_SET_NAME", setName);
-            cs.setString("P_TARGET_SERVER", targetServer);
-            cs.registerOutParameter("P_UPDATED_COUNT", Types.INTEGER);
-            cs.execute();
-            final int rowsUpdated = cs.getInt("P_UPDATED_COUNT");
-            cs.getConnection().commit();
-            cs.close();
-            if (rowsUpdated == 0) {
-                LOGGER.error("No rows updated when using the provided procedure for set {}, qual {}, targetServer {} to LSN {} and timestamp {} ",
-                        setName, applyQual, targetServer, synchPointLSN, synchInstant);
-            }
-            else if (rowsUpdated > 1) {
-                LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}. " +
-                        "Number updated was {} when using the provided procedure",
-                        setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
+                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()))
+            ) {
+                cs.setBytes("P_SYNCHPOINT", synchPointLSN.getBinary());
+                cs.setTimestamp("P_SYNCHTIME", Timestamp.from(synchInstant));
+                cs.setString("P_APPLY_QUAL", applyQual);
+                cs.setString("P_SET_NAME", setName);
+                cs.setString("P_TARGET_SERVER", targetServer);
+                cs.registerOutParameter("P_UPDATED_COUNT", Types.INTEGER);
+                cs.execute();
+                final int rowsUpdated = cs.getInt("P_UPDATED_COUNT");
+                cs.getConnection().commit();
+                if (rowsUpdated == 0) {
+                    LOGGER.error("No rows updated when using the provided procedure for set {}, qual {}, targetServer {} to LSN {} and timestamp {} ",
+                            setName, applyQual, targetServer, synchPointLSN, synchInstant);
+                } else if (rowsUpdated > 1) {
+                    LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}. " +
+                                    "Number updated was {} when using the provided procedure",
+                            setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
+                }
             }
         }
         else {

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -442,7 +442,7 @@ public class Db2Connection extends JdbcConnection {
         LOGGER.trace("Updating prune point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
 
         if (connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName() != null) {
-            LOGGER.info("Using database procedure for prune update as configuration specifies to use {}",
+            LOGGER.debug("Using database procedure for prune update as configuration specifies to use {}",
                     connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName());
             /*
              * Implementation must have this interface:

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -6,11 +6,7 @@
 
 package io.debezium.connector.db2;
 
-import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -438,14 +434,47 @@ public class Db2Connection extends JdbcConnection {
         final String updateSql = platform.getUpdatePruneSetForPruneSetName();
 
         LOGGER.trace("Updating prune point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
-        JdbcConnection updateConnection = prepareUpdate(updateSql, ps -> {
-            ps.setBytes(1, synchPointLSN.getBinary());
-            ps.setTimestamp(2, Timestamp.from(synchInstant));
-            ps.setString(3, applyQual);
-            ps.setString(4, setName);
-            ps.setString(5, targetServer);
-        });
-        updateConnection.commit();
+
+        if(connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName() != null){
+            LOGGER.info("Using database procedure for prune update as configuration specifies to use {}",
+                    connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName());
+                /*
+                    Implementation must have this interface:
+                    IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+                    IN P_SYNCHTIME TIMESTAMP,
+                    IN P_APPLY_QUAL VARCHAR(18),
+                    IN P_SET_NAME VARCHAR(18),
+                    IN P_TARGET_SERVER VARCHAR(18),
+                    OUT P_UPDATED_COUNT INT
+                */
+            final CallableStatement cs = connection().prepareCall(
+                    platform.getUpdatePruneSetProcedureCall(
+                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()
+                    )
+            );
+            cs.setBytes(    1, synchPointLSN.getBinary());
+            cs.setTimestamp(2, Timestamp.from(synchInstant));
+            cs.setString(   3, applyQual);
+            cs.setString(   4, setName);
+            cs.setString(   5, targetServer);
+        }
+        else {
+            int rowsUpdated = prepareUpdateExecuteCommit(updateSql, ps -> {
+                ps.setBytes(1, synchPointLSN.getBinary());
+                ps.setTimestamp(2, Timestamp.from(synchInstant));
+                ps.setString(3, applyQual);
+                ps.setString(4, setName);
+                ps.setString(5, targetServer);
+            });
+            if (rowsUpdated == 0) {
+                LOGGER.error("No rows updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}",
+                        setName, applyQual, targetServer, synchPointLSN, synchInstant);
+            } else if (rowsUpdated > 1) {
+                LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}.  " +
+                                "Number updated was {}",
+                        setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
+            }
+        }
     }
 
     public String getNameOfChangeTable(String captureName) {
@@ -608,6 +637,19 @@ public class Db2Connection extends JdbcConnection {
             statement.execute();
         }
         return this;
+    }
+
+    public int prepareUpdateExecuteCommit(String stmt, StatementPreparer preparer) throws SQLException {
+        // Db2 requires closing prepared statements to avoid caching result-set column structures
+        try (PreparedStatement statement = createPreparedStatement(stmt)) {
+            if (preparer != null) {
+                preparer.accept(statement);
+            }
+            LOGGER.trace("Executing statement '{}'", stmt);
+            statement.execute();
+            statement.getConnection().commit();
+            return statement.getUpdateCount();
+        }
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -455,8 +455,7 @@ public class Db2Connection extends JdbcConnection {
              */
             try (final CallableStatement cs = connection().prepareCall(
                     platform.getUpdatePruneSetProcedureCall(
-                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()))
-            ) {
+                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()))) {
                 cs.setBytes("P_SYNCHPOINT", synchPointLSN.getBinary());
                 cs.setTimestamp("P_SYNCHTIME", Timestamp.from(synchInstant));
                 cs.setString("P_APPLY_QUAL", applyQual);
@@ -469,9 +468,10 @@ public class Db2Connection extends JdbcConnection {
                 if (rowsUpdated == 0) {
                     LOGGER.error("No rows updated when using the provided procedure for set {}, qual {}, targetServer {} to LSN {} and timestamp {} ",
                             setName, applyQual, targetServer, synchPointLSN, synchInstant);
-                } else if (rowsUpdated > 1) {
+                }
+                else if (rowsUpdated > 1) {
                     LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}. " +
-                                    "Number updated was {} when using the provided procedure",
+                            "Number updated was {} when using the provided procedure",
                             setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
                 }
             }

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -453,7 +453,7 @@ public class Db2Connection extends JdbcConnection {
              * IN P_TARGET_SERVER VARCHAR(18),
              * OUT P_UPDATED_COUNT INT
              */
-            try (final CallableStatement cs = connection().prepareCall(
+            try (CallableStatement cs = connection().prepareCall(
                     platform.getUpdatePruneSetProcedureCall(
                             connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()))) {
                 cs.setBytes("P_SYNCHPOINT", synchPointLSN.getBinary());

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -423,6 +423,31 @@ public class Db2Connection extends JdbcConnection {
                 .create();
     }
 
+    /**
+     * Updates the timestamp and LSN of the current point the connector has produced for.
+     *
+     * @param synchPointLSN     - the last LSN that can be purged
+     * @param synchInstant      - the last Instant that can be purged
+     * @param applyQual         - the Apply qualifier that identifies which Apply program is processing this set.
+     * @param setName           - the name of the subscription set that this update applies to.
+     * @param targetServer      - the server name where target tables or views for this set reside.
+     */
+    public void updatePurgePointForSubSet(final Lsn synchPointLSN, final Instant synchInstant, final String applyQual,
+                                          final String setName, final String targetServer) throws SQLException {
+        final String updateSql = platform.getUpdatePurgeSetForPurgeSetName();
+
+        LOGGER.trace("Updating purge point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
+        JdbcConnection updateConnection =
+                prepareUpdate(updateSql, ps -> {
+                    ps.setTimestamp(1, Timestamp.from(synchInstant));
+                    ps.setBytes(2, synchPointLSN.getBinary());
+                    ps.setString(3, applyQual);
+                    ps.setString(4, setName);
+                    ps.setString(5, targetServer);
+                });
+        updateConnection.commit();
+    }
+
     public String getNameOfChangeTable(String captureName) {
         return captureName + "_CT";
     }

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -426,25 +426,25 @@ public class Db2Connection extends JdbcConnection {
     /**
      * Updates the timestamp and LSN of the current point the connector has produced for.
      *
-     * @param synchPointLSN     - the last LSN that can be purged
-     * @param synchInstant      - the last Instant that can be purged
+     * @param synchPointLSN     - the last LSN that can be pruned
+     * @param synchInstant      - the last Instant that can be pruned
      * @param applyQual         - the Apply qualifier that identifies which Apply program is processing this set.
      * @param setName           - the name of the subscription set that this update applies to.
      * @param targetServer      - the server name where target tables or views for this set reside.
      */
-    public void updatePurgePointForSubSet(final Lsn synchPointLSN, final Instant synchInstant, final String applyQual,
-                                          final String setName, final String targetServer) throws SQLException {
-        final String updateSql = platform.getUpdatePurgeSetForPurgeSetName();
+    public void updatePrunePointForSubSet(final Lsn synchPointLSN, final Instant synchInstant, final String applyQual,
+                                          final String setName, final String targetServer)
+            throws SQLException {
+        final String updateSql = platform.getUpdatePruneSetForPruneSetName();
 
-        LOGGER.trace("Updating purge point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
-        JdbcConnection updateConnection =
-                prepareUpdate(updateSql, ps -> {
-                    ps.setTimestamp(1, Timestamp.from(synchInstant));
-                    ps.setBytes(2, synchPointLSN.getBinary());
-                    ps.setString(3, applyQual);
-                    ps.setString(4, setName);
-                    ps.setString(5, targetServer);
-                });
+        LOGGER.trace("Updating prune point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
+        JdbcConnection updateConnection = prepareUpdate(updateSql, ps -> {
+            ps.setBytes(1, synchPointLSN.getBinary());
+            ps.setTimestamp(2, Timestamp.from(synchInstant));
+            ps.setString(3, applyQual);
+            ps.setString(4, setName);
+            ps.setString(5, targetServer);
+        });
         updateConnection.commit();
     }
 

--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -435,28 +435,41 @@ public class Db2Connection extends JdbcConnection {
 
         LOGGER.trace("Updating prune point for set {} to LSN {} and timestamp {}", setName, synchPointLSN, synchInstant);
 
-        if(connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName() != null){
+        if (connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName() != null) {
             LOGGER.info("Using database procedure for prune update as configuration specifies to use {}",
                     connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName());
-                /*
-                    Implementation must have this interface:
-                    IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
-                    IN P_SYNCHTIME TIMESTAMP,
-                    IN P_APPLY_QUAL VARCHAR(18),
-                    IN P_SET_NAME VARCHAR(18),
-                    IN P_TARGET_SERVER VARCHAR(18),
-                    OUT P_UPDATED_COUNT INT
-                */
+            /*
+             * Implementation must have this interface:
+             * IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+             * IN P_SYNCHTIME TIMESTAMP,
+             * IN P_APPLY_QUAL VARCHAR(18),
+             * IN P_SET_NAME VARCHAR(18),
+             * IN P_TARGET_SERVER VARCHAR(18),
+             * OUT P_UPDATED_COUNT INT
+             */
             final CallableStatement cs = connection().prepareCall(
                     platform.getUpdatePruneSetProcedureCall(
-                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()
-                    )
-            );
-            cs.setBytes(    1, synchPointLSN.getBinary());
-            cs.setTimestamp(2, Timestamp.from(synchInstant));
-            cs.setString(   3, applyQual);
-            cs.setString(   4, setName);
-            cs.setString(   5, targetServer);
+                            connectorConfig.getUpdateCaptureTablePruneProcedureOverrideName()));
+
+            cs.setBytes("P_SYNCHPOINT", synchPointLSN.getBinary());
+            cs.setTimestamp("P_SYNCHTIME", Timestamp.from(synchInstant));
+            cs.setString("P_APPLY_QUAL", applyQual);
+            cs.setString("P_SET_NAME", setName);
+            cs.setString("P_TARGET_SERVER", targetServer);
+            cs.registerOutParameter("P_UPDATED_COUNT", Types.INTEGER);
+            cs.execute();
+            final int rowsUpdated = cs.getInt("P_UPDATED_COUNT");
+            cs.getConnection().commit();
+            cs.close();
+            if (rowsUpdated == 0) {
+                LOGGER.error("No rows updated when using the provided procedure for set {}, qual {}, targetServer {} to LSN {} and timestamp {} ",
+                        setName, applyQual, targetServer, synchPointLSN, synchInstant);
+            }
+            else if (rowsUpdated > 1) {
+                LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}. " +
+                        "Number updated was {} when using the provided procedure",
+                        setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
+            }
         }
         else {
             int rowsUpdated = prepareUpdateExecuteCommit(updateSql, ps -> {
@@ -469,9 +482,10 @@ public class Db2Connection extends JdbcConnection {
             if (rowsUpdated == 0) {
                 LOGGER.error("No rows updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}",
                         setName, applyQual, targetServer, synchPointLSN, synchInstant);
-            } else if (rowsUpdated > 1) {
+            }
+            else if (rowsUpdated > 1) {
                 LOGGER.error("More than one row updated for set {}, qual {}, targetServer {} to LSN {} and timestamp {}.  " +
-                                "Number updated was {}",
+                        "Number updated was {}",
                         setName, applyQual, targetServer, synchPointLSN, synchInstant, rowsUpdated);
             }
         }

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -508,90 +508,60 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                 return 0;
             });
 
-    public static final Field UPDATE_CAPTURE_TABLE_PURGE_IND = Field.create("update.capture.table.purge.ind")
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_IND = Field.create("update.capture.table.prune.ind")
             .withDescription(
-                    "A switch to control if the connector instance is responsible for updating the purge table (usually " +
-                            "done by IBM Apply agent) which will cause the IBM Capture agent to purge read data from the change tables." +
+                    "A switch to control if the connector instance is responsible for updating the prune table (usually " +
+                            "done by IBM Apply agent) which will cause the IBM Capture agent to prune read data from the change tables." +
                             " default false.")
             .withType(Type.BOOLEAN)
             .withImportance(Importance.MEDIUM)
             .withWidth(Width.SHORT)
             .withDefault(false);
 
-    public static final Field UPDATE_CAPTURE_TABLE_PURGE_SET_NAME = Field.create("update.capture.table.purge.set.name")
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME = Field.create("update.capture.table.prune.set.name")
             .withDescription(
-                    "If set to update the purge table, this will identify the purge set name that should be used " +
+                    "If set to update the prune table, this will identify the prune set name that should be used " +
                             "when updating the table for this instance.")
             .withType(Type.STRING)
             .withImportance(Importance.MEDIUM)
             .withWidth(Width.MEDIUM)
             .withValidation((config, field, problems) -> {
                 String value = config.getString(field);
-                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
-                if (purgeInd && (value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is enabled, the set name must be " +
+                boolean pruneInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_IND);
+                if (pruneInd && (value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if prune update is enabled, the set name must be " +
                             "set to a non-empty string.");
                     return 1;
                 }
-                else if (!purgeInd && !(value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is disabled, the set name may not " +
+                else if (!pruneInd && !(value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if prune update is disabled, the set name may not " +
                             "be set to a value ");
                     return 1;
                 }
                 return 0;
             });
-    public static final Field UPDATE_CAPTURE_TABLE_PURGE_MIN_INTERVAL = Field.create("update.capture.table.purge.min.interval.ms")
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL = Field.create("update.capture.table.prune.min.interval.ms")
             .withDescription(
-                    "The minimum number of milliseconds between the connector instance's update of the purge point for " +
+                    "The minimum number of milliseconds between the connector instance's update of the prune point for " +
                             "the subscription set.  Default is 10000 (10 seconds).")
             .withType(Type.INT)
             .withImportance(Importance.LOW)
             .withWidth(Width.SHORT)
             .withDefault(10000);
 
-    public static final Field UPDATE_CAPTURE_TABLE_PURGE_APPLY_QUAL = Field.create("update.capture.table.purge.apply.qual")
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL = Field.create("update.capture.table.prune.apply.qual")
             .withDescription(
                     "The apply_qual name that represents the apply agent (this instance) to the subscription set.")
             .withType(Type.STRING)
             .withImportance(Importance.LOW)
-            .withWidth(Width.MEDIUM)
-            .withValidation((config, field, problems) -> {
-                String value = config.getString(field);
-                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
-                if (purgeInd && (value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is enabled, the apply_qual name must be " +
-                            "set to a non-empty string.");
-                    return 1;
-                }
-                else if (!purgeInd && !(value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is disabled, the apply_qual name may not " +
-                            "be set to a value ");
-                    return 1;
-                }
-                return 0;
-            });
+            .withWidth(Width.MEDIUM);
 
-    public static final Field UPDATE_CAPTURE_TABLE_PURGE_TARGET_SERVER = Field.create("update.capture.table.purge.target.server")
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER = Field.create("update.capture.table.prune.target.server")
             .withDescription(
                     "The target_server name that represents the apply agent's target (where the data is going) for the subscription set.")
             .withType(Type.STRING)
             .withImportance(Importance.LOW)
-            .withWidth(Width.MEDIUM)
-            .withValidation((config, field, problems) -> {
-                String value = config.getString(field);
-                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
-                if (purgeInd && (value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is enabled, the target_server name must be " +
-                            "set to a non-empty string.");
-                    return 1;
-                }
-                else if (!purgeInd && !(value == null || value.isEmpty())) {
-                    problems.accept(field, value, "The if purge update is disabled, the target_server name may not " +
-                            "be set to a value ");
-                    return 1;
-                }
-                return 0;
-            });
+            .withWidth(Width.MEDIUM);
 
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(Db2SourceInfoStructMaker.class.getName());
@@ -649,11 +619,11 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     private final int streamingQueryTimespanSeconds;
     private final boolean streamingQueryTimespanEnabled;
 
-    private final boolean updateCaptureTablePurgeInd;
-    private final String updateCaptureTablePurgeSetName;
-    private final int updateCaptureTablePurgeMinIntervalMs;
-    private final String updateCaptureTablePurgeApplyQual;
-    private final String updateCaptureTablePurgeTargetServer;
+    private final boolean updateCaptureTablePruneInd;
+    private final String updateCaptureTablePruneSetName;
+    private final int updateCaptureTablePruneMinIntervalMs;
+    private final String updateCaptureTablePruneApplyQual;
+    private final String updateCaptureTablePruneTargetServer;
 
     public Db2ConnectorConfig(Configuration config) {
         super(
@@ -686,11 +656,36 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         else {
             this.streamingQueryTimespanEnabled = true;
         }
-        this.updateCaptureTablePurgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
-        this.updateCaptureTablePurgeSetName = config.getString(UPDATE_CAPTURE_TABLE_PURGE_SET_NAME);
-        this.updateCaptureTablePurgeMinIntervalMs = config.getInteger(UPDATE_CAPTURE_TABLE_PURGE_MIN_INTERVAL);
-        this.updateCaptureTablePurgeApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PURGE_APPLY_QUAL);
-        this.updateCaptureTablePurgeTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PURGE_TARGET_SERVER);
+        this.updateCaptureTablePruneInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_IND);
+        this.updateCaptureTablePruneSetName = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME);
+        this.updateCaptureTablePruneMinIntervalMs = config.getInteger(UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL);
+        this.updateCaptureTablePruneApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL);
+        this.updateCaptureTablePruneTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER);
+        if(this.updateCaptureTablePruneInd){
+            if (this.updateCaptureTablePruneSetName == null || this.updateCaptureTablePruneSetName.isEmpty()) {
+                throw new ConfigException("The if prune update is enabled, the pruneSetName must be " +
+                        "set to a non-empty string.");
+            }
+            else if (this.updateCaptureTablePruneApplyQual == null || this.updateCaptureTablePruneApplyQual.isEmpty()) {
+                throw new ConfigException("The if prune update is enabled, the pruneApplyQual must be " +
+                        "set to a non-empty string.");
+            }
+            else if (this.updateCaptureTablePruneTargetServer == null || this.updateCaptureTablePruneTargetServer.isEmpty()) {
+                throw new ConfigException("The if prune update is enabled, the targetServer must be " +
+                        "set to a non-empty string.");
+            }
+        }
+        else {
+            if (this.updateCaptureTablePruneSetName != null) {
+                throw new ConfigException("The if prune update is disabled, the pruneSetName name may not be set to a value.");
+            }
+            if (this.updateCaptureTablePruneApplyQual != null) {
+                throw new ConfigException("The if prune update is disabled, the pruneApplyQual name may not be set to a value.");
+            }
+            if (this.updateCaptureTablePruneTargetServer != null) {
+                throw new ConfigException("The if prune update is disabled, the pruneTargetServer name may not be set to a value.");
+            }
+        }
     }
 
     public String getDatabaseName() {
@@ -733,24 +728,24 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         return streamingQueryTimespanEnabled;
     }
 
-    public boolean isUpdateCaptureTablePurgeInd() {
-        return updateCaptureTablePurgeInd;
+    public boolean isUpdateCaptureTablePruneInd() {
+        return updateCaptureTablePruneInd;
     }
 
-    public int getUpdateCaptureTablePurgeMinIntervalMs() {
-        return updateCaptureTablePurgeMinIntervalMs;
+    public int getUpdateCaptureTablePruneMinIntervalMs() {
+        return updateCaptureTablePruneMinIntervalMs;
     }
 
-    public String getUpdateCaptureTablePurgeSetName() {
-        return updateCaptureTablePurgeSetName;
+    public String getUpdateCaptureTablePruneSetName() {
+        return updateCaptureTablePruneSetName;
     }
 
-    public String getUpdateCaptureTablePurgeApplyQual() {
-        return updateCaptureTablePurgeApplyQual;
+    public String getUpdateCaptureTablePruneApplyQual() {
+        return updateCaptureTablePruneApplyQual;
     }
 
-    public String getUpdateCaptureTablePurgeTargetServer() {
-        return updateCaptureTablePurgeTargetServer;
+    public String getUpdateCaptureTablePruneTargetServer() {
+        return updateCaptureTablePruneTargetServer;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import io.debezium.util.Strings;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -39,6 +38,7 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.util.Strings;
 
 /**
  * The list of configuration options for DB2 connector

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -540,6 +540,58 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                 }
                 return 0;
             });
+    public static final Field UPDATE_CAPTURE_TABLE_PURGE_MIN_INTERVAL = Field.create("update.capture.table.purge.min.interval.ms")
+            .withDescription(
+                    "The minimum number of milliseconds between the connector instance's update of the purge point for " +
+                            "the subscription set.  Default is 10000 (10 seconds).")
+            .withType(Type.INT)
+            .withImportance(Importance.LOW)
+            .withWidth(Width.SHORT)
+            .withDefault(10000);
+
+    public static final Field UPDATE_CAPTURE_TABLE_PURGE_APPLY_QUAL = Field.create("update.capture.table.purge.apply.qual")
+            .withDescription(
+                    "The apply_qual name that represents the apply agent (this instance) to the subscription set.")
+            .withType(Type.STRING)
+            .withImportance(Importance.LOW)
+            .withWidth(Width.MEDIUM)
+            .withValidation((config, field, problems) -> {
+                String value = config.getString(field);
+                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
+                if (purgeInd && (value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is enabled, the apply_qual name must be " +
+                            "set to a non-empty string.");
+                    return 1;
+                }
+                else if (!purgeInd && !(value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is disabled, the apply_qual name may not " +
+                            "be set to a value ");
+                    return 1;
+                }
+                return 0;
+            });
+
+    public static final Field UPDATE_CAPTURE_TABLE_PURGE_TARGET_SERVER = Field.create("update.capture.table.purge.target.server")
+            .withDescription(
+                    "The target_server name that represents the apply agent's target (where the data is going) for the subscription set.")
+            .withType(Type.STRING)
+            .withImportance(Importance.LOW)
+            .withWidth(Width.MEDIUM)
+            .withValidation((config, field, problems) -> {
+                String value = config.getString(field);
+                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
+                if (purgeInd && (value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is enabled, the target_server name must be " +
+                            "set to a non-empty string.");
+                    return 1;
+                }
+                else if (!purgeInd && !(value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is disabled, the target_server name may not " +
+                            "be set to a value ");
+                    return 1;
+                }
+                return 0;
+            });
 
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(Db2SourceInfoStructMaker.class.getName());
@@ -599,6 +651,9 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     private final boolean updateCaptureTablePurgeInd;
     private final String updateCaptureTablePurgeSetName;
+    private final int updateCaptureTablePurgeMinIntervalMs;
+    private final String updateCaptureTablePurgeApplyQual;
+    private final String updateCaptureTablePurgeTargetServer;
 
     public Db2ConnectorConfig(Configuration config) {
         super(
@@ -633,6 +688,9 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         }
         this.updateCaptureTablePurgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
         this.updateCaptureTablePurgeSetName = config.getString(UPDATE_CAPTURE_TABLE_PURGE_SET_NAME);
+        this.updateCaptureTablePurgeMinIntervalMs = config.getInteger(UPDATE_CAPTURE_TABLE_PURGE_MIN_INTERVAL);
+        this.updateCaptureTablePurgeApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PURGE_APPLY_QUAL);
+        this.updateCaptureTablePurgeTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PURGE_TARGET_SERVER);
     }
 
     public String getDatabaseName() {
@@ -679,8 +737,20 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         return updateCaptureTablePurgeInd;
     }
 
+    public int getUpdateCaptureTablePurgeMinIntervalMs() {
+        return updateCaptureTablePurgeMinIntervalMs;
+    }
+
     public String getUpdateCaptureTablePurgeSetName() {
         return updateCaptureTablePurgeSetName;
+    }
+
+    public String getUpdateCaptureTablePurgeApplyQual() {
+        return updateCaptureTablePurgeApplyQual;
+    }
+
+    public String getUpdateCaptureTablePurgeTargetServer() {
+        return updateCaptureTablePurgeTargetServer;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -530,12 +530,12 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                 String value = config.getString(field);
                 boolean pruneInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_IND);
                 if (pruneInd && Strings.isNullOrEmpty(value)) {
-                    problems.accept(field, value, "The if prune update is enabled, the set name must be " +
+                    problems.accept(field, value, "If prune update is enabled, the set name must be " +
                             "set to a non-empty string.");
                     return 1;
                 }
                 else if (!pruneInd && !Strings.isNullOrEmpty(value)) {
-                    problems.accept(field, value, "The if prune update is disabled, the set name may not " +
+                    problems.accept(field, value, "If prune update is disabled, the set name may not " +
                             "be set to a value ");
                     return 1;
                 }
@@ -600,7 +600,14 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     QUERY_FETCH_SIZE,
                     CDC_CONTROL_SCHEMA,
                     CDC_CHANGE_TABLES_SCHEMA,
-                    DB2_PLATFORM)
+                    DB2_PLATFORM,
+                    UPDATE_CAPTURE_TABLE_PRUNE_IND,
+                    UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME,
+                    UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL,
+                    UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT,
+                    UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL,
+                    UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER,
+                    UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME)
             .events(SOURCE_INFO_STRUCT_MAKER)
             .excluding(
                     SCHEMA_INCLUDE_LIST,

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.debezium.util.Strings;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -528,12 +529,12 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             .withValidation((config, field, problems) -> {
                 String value = config.getString(field);
                 boolean pruneInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_IND);
-                if (pruneInd && (value == null || value.isEmpty())) {
+                if (pruneInd && Strings.isNullOrEmpty(value)) {
                     problems.accept(field, value, "The if prune update is enabled, the set name must be " +
                             "set to a non-empty string.");
                     return 1;
                 }
-                else if (!pruneInd && !(value == null || value.isEmpty())) {
+                else if (!pruneInd && !Strings.isNullOrEmpty(value)) {
                     problems.accept(field, value, "The if prune update is disabled, the set name may not " +
                             "be set to a value ");
                     return 1;
@@ -683,31 +684,6 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.updateCaptureTablePruneApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL);
         this.updateCaptureTablePruneTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER);
         this.updateCaptureTablePruneProcedureOverrideName = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME);
-        if (this.updateCaptureTablePruneInd) {
-            if (this.updateCaptureTablePruneSetName == null || this.updateCaptureTablePruneSetName.isEmpty()) {
-                throw new ConfigException("The if prune update is enabled, the pruneSetName must be " +
-                        "set to a non-empty string.");
-            }
-            else if (this.updateCaptureTablePruneApplyQual == null || this.updateCaptureTablePruneApplyQual.isEmpty()) {
-                throw new ConfigException("The if prune update is enabled, the pruneApplyQual must be " +
-                        "set to a non-empty string.");
-            }
-            else if (this.updateCaptureTablePruneTargetServer == null || this.updateCaptureTablePruneTargetServer.isEmpty()) {
-                throw new ConfigException("The if prune update is enabled, the targetServer must be " +
-                        "set to a non-empty string.");
-            }
-        }
-        else {
-            if (this.updateCaptureTablePruneSetName != null) {
-                throw new ConfigException("The if prune update is disabled, the pruneSetName name may not be set to a value.");
-            }
-            if (this.updateCaptureTablePruneApplyQual != null) {
-                throw new ConfigException("The if prune update is disabled, the pruneApplyQual name may not be set to a value.");
-            }
-            if (this.updateCaptureTablePruneTargetServer != null) {
-                throw new ConfigException("The if prune update is disabled, the pruneTargetServer name may not be set to a value.");
-            }
-        }
     }
 
     public String getDatabaseName() {

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -572,6 +572,13 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             .withImportance(Importance.LOW)
             .withWidth(Width.MEDIUM);
 
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME = Field.create("update.capture.table.prune.procedure.override.name")
+            .withDescription(
+                    "The name of a prepared statement in the database that will be used instead of direct sql to allow for DBA control of the update code where needed.")
+            .withType(Type.STRING)
+            .withImportance(Importance.LOW)
+            .withWidth(Width.LONG);
+
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(Db2SourceInfoStructMaker.class.getName());
 
@@ -636,6 +643,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     private final String updateCaptureTablePruneApplyQual;
     private final String updateCaptureTablePruneTargetServer;
 
+    private final String updateCaptureTablePruneProcedureOverrideName;
+
     public Db2ConnectorConfig(Configuration config) {
         super(
                 Db2Connector.class,
@@ -673,6 +682,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.updateCaptureTablePruneLsnDecrement = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT);
         this.updateCaptureTablePruneApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL);
         this.updateCaptureTablePruneTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER);
+        this.updateCaptureTablePruneProcedureOverrideName = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME);
         if (this.updateCaptureTablePruneInd) {
             if (this.updateCaptureTablePruneSetName == null || this.updateCaptureTablePruneSetName.isEmpty()) {
                 throw new ConfigException("The if prune update is enabled, the pruneSetName must be " +
@@ -762,6 +772,10 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     public String getUpdateCaptureTablePruneTargetServer() {
         return updateCaptureTablePruneTargetServer;
+    }
+
+    public String getUpdateCaptureTablePruneProcedureOverrideName() {
+        return updateCaptureTablePruneProcedureOverrideName;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -549,6 +549,15 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             .withWidth(Width.SHORT)
             .withDefault(10000);
 
+    public static final Field UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT = Field.create("update.capture.table.prune.lsn.decrement")
+            .withDescription(
+                    "An switch to decrement the prune lsn/syncpoint by one to avoid allowing the last lsn processed to get pruned " +
+                            "to avoid the risk of an unnecessary snapshot due to the last processed lsn not being present in the change table.")
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.LOW)
+            .withWidth(Width.MEDIUM)
+            .withDefault(true);
+
     public static final Field UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL = Field.create("update.capture.table.prune.apply.qual")
             .withDescription(
                     "The apply_qual name that represents the apply agent (this instance) to the subscription set.")
@@ -622,6 +631,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     private final boolean updateCaptureTablePruneInd;
     private final String updateCaptureTablePruneSetName;
     private final int updateCaptureTablePruneMinIntervalMs;
+
+    private final boolean updateCaptureTablePruneLsnDecrement;
     private final String updateCaptureTablePruneApplyQual;
     private final String updateCaptureTablePruneTargetServer;
 
@@ -659,9 +670,10 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.updateCaptureTablePruneInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_IND);
         this.updateCaptureTablePruneSetName = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME);
         this.updateCaptureTablePruneMinIntervalMs = config.getInteger(UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL);
+        this.updateCaptureTablePruneLsnDecrement = config.getBoolean(UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT);
         this.updateCaptureTablePruneApplyQual = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL);
         this.updateCaptureTablePruneTargetServer = config.getString(UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER);
-        if(this.updateCaptureTablePruneInd){
+        if (this.updateCaptureTablePruneInd) {
             if (this.updateCaptureTablePruneSetName == null || this.updateCaptureTablePruneSetName.isEmpty()) {
                 throw new ConfigException("The if prune update is enabled, the pruneSetName must be " +
                         "set to a non-empty string.");
@@ -734,6 +746,10 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     public int getUpdateCaptureTablePruneMinIntervalMs() {
         return updateCaptureTablePruneMinIntervalMs;
+    }
+
+    public boolean isUpdateCaptureTablePruneLsnDecrement() {
+        return updateCaptureTablePruneLsnDecrement;
     }
 
     public String getUpdateCaptureTablePruneSetName() {

--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -508,6 +508,39 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                 return 0;
             });
 
+    public static final Field UPDATE_CAPTURE_TABLE_PURGE_IND = Field.create("update.capture.table.purge.ind")
+            .withDescription(
+                    "A switch to control if the connector instance is responsible for updating the purge table (usually " +
+                            "done by IBM Apply agent) which will cause the IBM Capture agent to purge read data from the change tables." +
+                            " default false.")
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.MEDIUM)
+            .withWidth(Width.SHORT)
+            .withDefault(false);
+
+    public static final Field UPDATE_CAPTURE_TABLE_PURGE_SET_NAME = Field.create("update.capture.table.purge.set.name")
+            .withDescription(
+                    "If set to update the purge table, this will identify the purge set name that should be used " +
+                            "when updating the table for this instance.")
+            .withType(Type.STRING)
+            .withImportance(Importance.MEDIUM)
+            .withWidth(Width.MEDIUM)
+            .withValidation((config, field, problems) -> {
+                String value = config.getString(field);
+                boolean purgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
+                if (purgeInd && (value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is enabled, the set name must be " +
+                            "set to a non-empty string.");
+                    return 1;
+                }
+                else if (!purgeInd && !(value == null || value.isEmpty())) {
+                    problems.accept(field, value, "The if purge update is disabled, the set name may not " +
+                            "be set to a value ");
+                    return 1;
+                }
+                return 0;
+            });
+
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(Db2SourceInfoStructMaker.class.getName());
 
@@ -564,6 +597,9 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     private final int streamingQueryTimespanSeconds;
     private final boolean streamingQueryTimespanEnabled;
 
+    private final boolean updateCaptureTablePurgeInd;
+    private final String updateCaptureTablePurgeSetName;
+
     public Db2ConnectorConfig(Configuration config) {
         super(
                 Db2Connector.class,
@@ -595,6 +631,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         else {
             this.streamingQueryTimespanEnabled = true;
         }
+        this.updateCaptureTablePurgeInd = config.getBoolean(UPDATE_CAPTURE_TABLE_PURGE_IND);
+        this.updateCaptureTablePurgeSetName = config.getString(UPDATE_CAPTURE_TABLE_PURGE_SET_NAME);
     }
 
     public String getDatabaseName() {
@@ -635,6 +673,14 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     public boolean isStreamingQueryTimespanEnabled() {
         return streamingQueryTimespanEnabled;
+    }
+
+    public boolean isUpdateCaptureTablePurgeInd() {
+        return updateCaptureTablePurgeInd;
+    }
+
+    public String getUpdateCaptureTablePurgeSetName() {
+        return updateCaptureTablePurgeSetName;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -88,7 +87,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
     private final Duration pollInterval;
     private final Db2ConnectorConfig connectorConfig;
     private Db2OffsetContext effectiveOffsetContext;
-    private Instant lastPurgeUpdateInstant = Instant.MIN;
+    private Instant lastPruneUpdateInstant = Instant.EPOCH;
 
     private final SnapshotterService snapshotterService;
 
@@ -296,7 +295,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                     });
                     lastProcessedPosition = TxLogPosition.valueOf(currentMaxLsn);
                     LOGGER.info("Last processed position is {}", lastProcessedPosition);
-                    handleSubSetPurgeUpdate(currentMaxLsn);
+                    handleSubSetPruneUpdate(currentMaxLsn);
                     // Terminate the transaction otherwise CDC could not be disabled for tables
                     dataConnection.rollback();
                 }
@@ -311,42 +310,38 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
         }
     }
 
-    private void handleSubSetPurgeUpdate(Lsn currentMaxLsn) throws SQLException {
-        if(connectorConfig.isUpdateCaptureTablePurgeInd()){
-            // Calculate duration since last purge update
-            final Duration durationSinceLastPurgeUpdate = Duration.between(lastPurgeUpdateInstant, Instant.now());
-            final Duration durationOfMinimumInterval = Duration.of(connectorConfig.getUpdateCaptureTablePurgeMinIntervalMs(), ChronoUnit.MILLIS);
-            if(durationSinceLastPurgeUpdate.compareTo(durationOfMinimumInterval) >= 0){
-                LOGGER.info("Updating the purge point for the capture table as it has been {} since " +
-                        "the last purge update at {} and the minimum interval is {}.",
-                        durationSinceLastPurgeUpdate.toMillis(),
-                        lastPurgeUpdateInstant.toString(),
-                        durationOfMinimumInterval.toMillis()
-                );
-                lastPurgeUpdateInstant = Instant.now();
+    private void handleSubSetPruneUpdate(Lsn currentMaxLsn) throws SQLException {
+        if (connectorConfig.isUpdateCaptureTablePruneInd()) {
+            // Calculate duration since last prune update
+            final Duration durationSinceLastPruneUpdate = Duration.between(lastPruneUpdateInstant, Instant.now());
+            final Duration durationOfMinimumInterval = Duration.of(connectorConfig.getUpdateCaptureTablePruneMinIntervalMs(), ChronoUnit.MILLIS);
+            if (durationSinceLastPruneUpdate.compareTo(durationOfMinimumInterval) >= 0) {
+                LOGGER.info("Updating the prune point for the capture table as it has been {} since " +
+                        "the last prune update at {} and the minimum interval is {}.",
+                        durationSinceLastPruneUpdate.toMillis(),
+                        lastPruneUpdateInstant.toString(),
+                        durationOfMinimumInterval.toMillis());
+                lastPruneUpdateInstant = Instant.now();
                 final Instant currentMaxLsnInstant = dataConnection.timestampOfLsn(currentMaxLsn);
-                LOGGER.info("Updating the purge point for the capture table to the time of {} and the lsn of {}.",
+                LOGGER.info("Updating the prune point for the capture table to the time of {} and the lsn of {}.",
                         currentMaxLsnInstant.toString(),
                         currentMaxLsn);
 
-                dataConnection.updatePurgePointForSubSet(
+                dataConnection.updatePrunePointForSubSet(
                         currentMaxLsn,
                         currentMaxLsnInstant,
-                        connectorConfig.getUpdateCaptureTablePurgeApplyQual(),
-                        connectorConfig.getUpdateCaptureTablePurgeSetName(),
-                        connectorConfig.getUpdateCaptureTablePurgeTargetServer());
-                LOGGER.info("Updated the purge point for the capture table");
+                        connectorConfig.getUpdateCaptureTablePruneApplyQual(),
+                        connectorConfig.getUpdateCaptureTablePruneSetName(),
+                        connectorConfig.getUpdateCaptureTablePruneTargetServer());
+                LOGGER.info("Updated the prune point for the capture table");
             }
-            else{
-                LOGGER.info("Skipping updating the purge point for the capture table as it has been {} ms since " +
-                        "the last purge update at {} and the minimum interval is {} ms.",
-                        durationSinceLastPurgeUpdate.toMillis(),
-                        lastPurgeUpdateInstant.toString(),
-                        durationOfMinimumInterval.toMillis()
-                );
+            else {
+                LOGGER.info("Skipping updating the prune point for the capture table as it has been {} ms since " +
+                        "the last prune update at {} and the minimum interval is {} ms.",
+                        durationSinceLastPruneUpdate.toMillis(),
+                        lastPruneUpdateInstant.toString(),
+                        durationOfMinimumInterval.toMillis());
             }
-
-
         }
     }
 

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -323,7 +323,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
             final Duration durationSinceLastPruneUpdate = Duration.between(lastPruneUpdateInstant, Instant.now());
             final Duration durationOfMinimumInterval = Duration.of(connectorConfig.getUpdateCaptureTablePruneMinIntervalMs(), ChronoUnit.MILLIS);
             if (durationSinceLastPruneUpdate.compareTo(durationOfMinimumInterval) >= 0) {
-                LOGGER.info("Updating the prune point for the capture table as it has been {} since " +
+                LOGGER.debug("Updating the prune point for the capture table as it has been {} since " +
                         "the last prune update at {} and the minimum interval is {}.",
                         durationSinceLastPruneUpdate.toMillis(),
                         lastPruneUpdateInstant.toString(),
@@ -333,10 +333,10 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                 Lsn lsnToApply = currentMaxLsn;
                 if (connectorConfig.isUpdateCaptureTablePruneLsnDecrement()) {
                     final Lsn decrementedLsn = currentMaxLsn.decrement();
-                    LOGGER.info("Decrementing the prune point for the capture table by 1 LSN \nBefore: {} \nAfter: {}", lsnToApply, decrementedLsn);
+                    LOGGER.debug("Decrementing the prune point for the capture table by 1 LSN \nBefore: {} \nAfter: {}", lsnToApply, decrementedLsn);
                     lsnToApply = decrementedLsn;
                 }
-                LOGGER.info("Updating the prune point for the capture table to the time of {} and the lsn of {}.",
+                LOGGER.debug("Updating the prune point for the capture table to the time of {} and the lsn of {}.",
                         currentMaxLsnInstant.toString(),
                         lsnToApply);
 
@@ -346,10 +346,10 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                         connectorConfig.getUpdateCaptureTablePruneApplyQual(),
                         connectorConfig.getUpdateCaptureTablePruneSetName(),
                         connectorConfig.getUpdateCaptureTablePruneTargetServer());
-                LOGGER.info("Updated the prune point for the capture table");
+                LOGGER.debug("Updated the prune point for the capture table");
             }
             else {
-                LOGGER.info("Skipping updating the prune point for the capture table as it has been {} ms since " +
+                LOGGER.debug("Skipping updating the prune point for the capture table as it has been {} ms since " +
                         "the last prune update at {} and the minimum interval is {} ms.",
                         durationSinceLastPruneUpdate.toMillis(),
                         lastPruneUpdateInstant.toString(),

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -323,12 +323,18 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                         durationOfMinimumInterval.toMillis());
                 lastPruneUpdateInstant = Instant.now();
                 final Instant currentMaxLsnInstant = dataConnection.timestampOfLsn(currentMaxLsn);
+                Lsn lsnToApply = currentMaxLsn;
+                if (connectorConfig.isUpdateCaptureTablePruneLsnDecrement()) {
+                    final Lsn decrementedLsn = currentMaxLsn.decrement();
+                    LOGGER.info("Decrementing the prune point for the capture table by 1 LSN \nBefore: {} \nAfter: {}", lsnToApply, decrementedLsn);
+                    lsnToApply = decrementedLsn;
+                }
                 LOGGER.info("Updating the prune point for the capture table to the time of {} and the lsn of {}.",
                         currentMaxLsnInstant.toString(),
-                        currentMaxLsn);
+                        lsnToApply);
 
                 dataConnection.updatePrunePointForSubSet(
-                        currentMaxLsn,
+                        lsnToApply,
                         currentMaxLsnInstant,
                         connectorConfig.getUpdateCaptureTablePruneApplyQual(),
                         connectorConfig.getUpdateCaptureTablePruneSetName(),

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -292,13 +292,19 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                         }
                     });
                     lastProcessedPosition = TxLogPosition.valueOf(currentMaxLsn);
+                    LOGGER.info("Last processed position is {}", lastProcessedPosition);
+                    if(connectorConfig.isUpdateCaptureTablePurgeInd()){
+                        LOGGER.info("Updating the purge point for the capture table");
+                        dataConnection.updatePurgePointForSubSet(currentMaxLsn, Instant.now(),
+                                "applyQual", "setName", "targetServer"); //TODO: See if instant.now will be ok, fix the other hardcodes
+                        LOGGER.info("Updated the purge point for the capture table");
+                    }
                     // Terminate the transaction otherwise CDC could not be disabled for tables
                     dataConnection.rollback();
                 }
                 catch (SQLException e) {
                     tablesSlot.set(processErrorFromChangeTableQuery(e, tablesSlot.get()));
                 }
-
                 handlePause(context);
             }
         }

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -234,7 +234,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                             }
                             if (connectorConfig.isUpdateCaptureTablePruneInd()) { // The use of stop lsn doesn't seem to make sense
                                 LOGGER.info("Bypassing check for STOP_LSN against change LSN (taken from IBMSNAP_REGISTER), " +
-                                        "a value that can't be null when using purge, and will quickly be too old to pass this test.");
+                                        "a value that can't be null when using prune, and will quickly be too old to pass this test.");
                             }
                             else {
                                 if (tableWithSmallestLsn.getChangeTable().getStopLsn().isAvailable() &&

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -232,12 +232,18 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                                         Db2ConnectorConfig.Z_STOP_LSN_IGNORE.name(),
                                         tableWithSmallestLsn.getChangeTable().getStopLsn());
                             }
-                            if (tableWithSmallestLsn.getChangeTable().getStopLsn().isAvailable() &&
-                                    tableWithSmallestLsn.getChangeTable().getStopLsn().compareTo(tableWithSmallestLsn.getChangePosition().getCommitLsn()) <= 0) {
-                                LOGGER.debug("Skipping table change {} as its stop LSN is smaller than the last recorded LSN {}", tableWithSmallestLsn,
-                                        tableWithSmallestLsn.getChangePosition());
-                                tableWithSmallestLsn.next();
-                                continue;
+                            if (connectorConfig.isUpdateCaptureTablePruneInd()) { // The use of stop lsn doesn't seem to make sense
+                                LOGGER.info("Bypassing check for STOP_LSN against change LSN (taken from IBMSNAP_REGISTER), " +
+                                        "a value that can't be null when using purge, and will quickly be too old to pass this test.");
+                            }
+                            else {
+                                if (tableWithSmallestLsn.getChangeTable().getStopLsn().isAvailable() &&
+                                        tableWithSmallestLsn.getChangeTable().getStopLsn().compareTo(tableWithSmallestLsn.getChangePosition().getCommitLsn()) <= 0) {
+                                    LOGGER.debug("Skipping table change {} as its stop LSN is smaller than the last recorded LSN {}", tableWithSmallestLsn,
+                                            tableWithSmallestLsn.getChangePosition());
+                                    tableWithSmallestLsn.next();
+                                    continue;
+                                }
                             }
                             LOGGER.trace("Processing change {}", tableWithSmallestLsn);
                             if (!schemaChangeCheckpoints.isEmpty()) {
@@ -294,16 +300,17 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                         }
                     });
                     lastProcessedPosition = TxLogPosition.valueOf(currentMaxLsn);
-                    LOGGER.info("Last processed position is {}", lastProcessedPosition);
-                    handleSubSetPruneUpdate(currentMaxLsn);
+
                     // Terminate the transaction otherwise CDC could not be disabled for tables
                     dataConnection.rollback();
                 }
                 catch (SQLException e) {
                     tablesSlot.set(processErrorFromChangeTableQuery(e, tablesSlot.get()));
                 }
+                LOGGER.info("Last processed position is {}", lastProcessedPosition);
+                handleSubSetPruneUpdate(currentMaxLsn);
                 handlePause(context);
-            }
+            } // End Running While Loop
         }
         catch (Exception e) {
             errorHandler.setProducerThrowable(e);

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -9,6 +9,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -86,6 +88,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
     private final Duration pollInterval;
     private final Db2ConnectorConfig connectorConfig;
     private Db2OffsetContext effectiveOffsetContext;
+    private Instant lastPurgeUpdateInstant = Instant.MIN;
 
     private final SnapshotterService snapshotterService;
 
@@ -293,12 +296,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                     });
                     lastProcessedPosition = TxLogPosition.valueOf(currentMaxLsn);
                     LOGGER.info("Last processed position is {}", lastProcessedPosition);
-                    if(connectorConfig.isUpdateCaptureTablePurgeInd()){
-                        LOGGER.info("Updating the purge point for the capture table");
-                        dataConnection.updatePurgePointForSubSet(currentMaxLsn, Instant.now(),
-                                "applyQual", "setName", "targetServer"); //TODO: See if instant.now will be ok, fix the other hardcodes
-                        LOGGER.info("Updated the purge point for the capture table");
-                    }
+                    handleSubSetPurgeUpdate(currentMaxLsn);
                     // Terminate the transaction otherwise CDC could not be disabled for tables
                     dataConnection.rollback();
                 }
@@ -310,6 +308,45 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
         }
         catch (Exception e) {
             errorHandler.setProducerThrowable(e);
+        }
+    }
+
+    private void handleSubSetPurgeUpdate(Lsn currentMaxLsn) throws SQLException {
+        if(connectorConfig.isUpdateCaptureTablePurgeInd()){
+            // Calculate duration since last purge update
+            final Duration durationSinceLastPurgeUpdate = Duration.between(lastPurgeUpdateInstant, Instant.now());
+            final Duration durationOfMinimumInterval = Duration.of(connectorConfig.getUpdateCaptureTablePurgeMinIntervalMs(), ChronoUnit.MILLIS);
+            if(durationSinceLastPurgeUpdate.compareTo(durationOfMinimumInterval) >= 0){
+                LOGGER.info("Updating the purge point for the capture table as it has been {} since " +
+                        "the last purge update at {} and the minimum interval is {}.",
+                        durationSinceLastPurgeUpdate.toMillis(),
+                        lastPurgeUpdateInstant.toString(),
+                        durationOfMinimumInterval.toMillis()
+                );
+                lastPurgeUpdateInstant = Instant.now();
+                final Instant currentMaxLsnInstant = dataConnection.timestampOfLsn(currentMaxLsn);
+                LOGGER.info("Updating the purge point for the capture table to the time of {} and the lsn of {}.",
+                        currentMaxLsnInstant.toString(),
+                        currentMaxLsn);
+
+                dataConnection.updatePurgePointForSubSet(
+                        currentMaxLsn,
+                        currentMaxLsnInstant,
+                        connectorConfig.getUpdateCaptureTablePurgeApplyQual(),
+                        connectorConfig.getUpdateCaptureTablePurgeSetName(),
+                        connectorConfig.getUpdateCaptureTablePurgeTargetServer());
+                LOGGER.info("Updated the purge point for the capture table");
+            }
+            else{
+                LOGGER.info("Skipping updating the purge point for the capture table as it has been {} ms since " +
+                        "the last purge update at {} and the minimum interval is {} ms.",
+                        durationSinceLastPurgeUpdate.toMillis(),
+                        lastPurgeUpdateInstant.toString(),
+                        durationOfMinimumInterval.toMillis()
+                );
+            }
+
+
         }
     }
 

--- a/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/db2/Db2StreamingChangeEventSource.java
@@ -307,7 +307,7 @@ public class Db2StreamingChangeEventSource implements StreamingChangeEventSource
                 catch (SQLException e) {
                     tablesSlot.set(processErrorFromChangeTableQuery(e, tablesSlot.get()));
                 }
-                LOGGER.info("Last processed position is {}", lastProcessedPosition);
+                LOGGER.debug("Last processed position is {}", lastProcessedPosition);
                 handleSubSetPruneUpdate(currentMaxLsn);
                 handlePause(context);
             } // End Running While Loop

--- a/src/main/java/io/debezium/connector/db2/Lsn.java
+++ b/src/main/java/io/debezium/connector/db2/Lsn.java
@@ -27,7 +27,7 @@ public class Lsn implements Comparable<Lsn>, Nullable {
     public static final Lsn NULL = new Lsn(null);
     public static final Lsn ZERO = new Lsn(new byte[16]);
 
-    private static Logger LOGGER = LoggerFactory.getLogger(Lsn.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Lsn.class);
 
     private final byte[] binary;
     private int[] unsignedBinary;

--- a/src/main/java/io/debezium/connector/db2/Lsn.java
+++ b/src/main/java/io/debezium/connector/db2/Lsn.java
@@ -31,7 +31,6 @@ public class Lsn implements Comparable<Lsn>, Nullable {
 
     private final byte[] binary;
     private int[] unsignedBinary;
-
     private String string;
 
     private Lsn(byte[] binary) {

--- a/src/main/java/io/debezium/connector/db2/Lsn.java
+++ b/src/main/java/io/debezium/connector/db2/Lsn.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 
 import io.debezium.connector.Nullable;
 import io.debezium.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A logical representation of DB2 LSN (log sequence number) position. When LSN is not available
@@ -22,6 +24,9 @@ public class Lsn implements Comparable<Lsn>, Nullable {
     private static final String NULL_STRING = "NULL";
 
     public static final Lsn NULL = new Lsn(null);
+    public static final Lsn ZERO = new Lsn(new byte[16]);
+
+    private static Logger LOGGER = LoggerFactory.getLogger(Lsn.class);
 
     private final byte[] binary;
     private int[] unsignedBinary;
@@ -184,6 +189,10 @@ public class Lsn implements Comparable<Lsn>, Nullable {
      * Return the prior LSN in sequence
      */
     public Lsn decrement() {
+        if (this.equals(Lsn.ZERO)) {
+            LOGGER.warn("Cannot decrement LSN {} as it is zero", this);
+            return this;
+        }
         final BigInteger bi = new BigInteger(this.toString().replace(":", ""), 16).subtract(BigInteger.ONE);
         final byte[] biByteArray = bi.toByteArray();
         final byte[] lsnByteArray = new byte[16];

--- a/src/main/java/io/debezium/connector/db2/Lsn.java
+++ b/src/main/java/io/debezium/connector/db2/Lsn.java
@@ -179,4 +179,17 @@ public class Lsn implements Comparable<Lsn>, Nullable {
         }
         return Lsn.valueOf(lsnByteArray);
     }
+
+    /**
+     * Return the prior LSN in sequence
+     */
+    public Lsn decrement() {
+        final BigInteger bi = new BigInteger(this.toString().replace(":", ""), 16).subtract(BigInteger.ONE);
+        final byte[] biByteArray = bi.toByteArray();
+        final byte[] lsnByteArray = new byte[16];
+        for (int i = 0; i < biByteArray.length; i++) {
+            lsnByteArray[i + 16 - biByteArray.length] = biByteArray[i];
+        }
+        return Lsn.valueOf(lsnByteArray);
+    }
 }

--- a/src/main/java/io/debezium/connector/db2/Lsn.java
+++ b/src/main/java/io/debezium/connector/db2/Lsn.java
@@ -8,10 +8,11 @@ package io.debezium.connector.db2;
 import java.math.BigInteger;
 import java.util.Arrays;
 
-import io.debezium.connector.Nullable;
-import io.debezium.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.Nullable;
+import io.debezium.util.Strings;
 
 /**
  * A logical representation of DB2 LSN (log sequence number) position. When LSN is not available

--- a/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
+++ b/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
@@ -23,4 +23,6 @@ public interface Db2PlatformAdapter {
     String getListOfNewCdcEnabledTablesQuery();
 
     String getUpdatePruneSetForPruneSetName();
+
+    String getUpdatePruneSetProcedureCall(final String procedureName);
 }

--- a/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
+++ b/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
@@ -22,5 +22,5 @@ public interface Db2PlatformAdapter {
 
     String getListOfNewCdcEnabledTablesQuery();
 
-    String getUpdatePurgeSetForPurgeSetName();
+    String getUpdatePruneSetForPruneSetName();
 }

--- a/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
+++ b/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
@@ -21,4 +21,6 @@ public interface Db2PlatformAdapter {
     String getListOfCdcEnabledTablesQuery();
 
     String getListOfNewCdcEnabledTablesQuery();
+
+    String getUpdatePurgeSetForPurgeSetName();
 }

--- a/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
+++ b/src/main/java/io/debezium/connector/db2/platform/Db2PlatformAdapter.java
@@ -24,5 +24,5 @@ public interface Db2PlatformAdapter {
 
     String getUpdatePruneSetForPruneSetName();
 
-    String getUpdatePruneSetProcedureCall(final String procedureName);
+    String getUpdatePruneSetProcedureCall(String procedureName);
 }

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -78,15 +78,16 @@ public class LuwPlatform implements Db2PlatformAdapter {
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
 
-        this.updatePruneSetForPruneSetName = "" +
-                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PRUNE_SET " +
-                "SET " +
-                "  SYNCHPOINT = ?, " +
-                "  SYNCHTIME = ? " +
-                "WHERE " +
-                "   APPLY_QUAL = ? AND " +
-                "   SET_NAME = ? AND " +
-                "   TARGET_SERVER = ?;";
+        this.updatePruneSetForPruneSetName = """
+                UPDATE %s.IBMSNAP_PRUNE_SET
+                SET
+                    SYNCHPOINT = ?,
+                    SYNCHTIME = ?
+                WHERE
+                    APPLY_QUAL = ? AND
+                    SET_NAME = ? AND
+                    TARGET_SERVER = ?;
+                """.formatted(connectorConfig.getCdcControlSchema());
 
         /*
          * Implementation must have this interface:
@@ -97,10 +98,9 @@ public class LuwPlatform implements Db2PlatformAdapter {
          * IN P_TARGET_SERVER VARCHAR(18),
          * OUT P_UPDATED_COUNT INT
          */
-        this.updatePruneSetProcedureCall = "" +
-                "CALL " +
-                PROCEDURE_NAME_PLACEHOLDER +
-                " (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)"; // 6 ? placeholders: positions 1-5 IN, 6 OUT
+        this.updatePruneSetProcedureCall = """
+                CALL %s (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)
+                """.formatted(PROCEDURE_NAME_PLACEHOLDER); // 6 ? placeholders: positions 1-5 IN, 6 OUT
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -88,20 +88,21 @@ public class LuwPlatform implements Db2PlatformAdapter {
                 "   SET_NAME = ? AND " +
                 "   TARGET_SERVER = ?;";
 
-    /*
-            Implementation must have this interface:
-                IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
-                IN P_SYNCHTIME TIMESTAMP,
-                IN P_APPLY_QUAL VARCHAR(18),
-                IN P_SET_NAME VARCHAR(18),
-                IN P_TARGET_SERVER VARCHAR(18),
-                OUT P_UPDATED_COUNT INT
+        /*
+         * Implementation must have this interface:
+         * IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+         * IN P_SYNCHTIME TIMESTAMP,
+         * IN P_APPLY_QUAL VARCHAR(18),
+         * IN P_SET_NAME VARCHAR(18),
+         * IN P_TARGET_SERVER VARCHAR(18),
+         * OUT P_UPDATED_COUNT INT
          */
         this.updatePruneSetProcedureCall = "" +
                 "CALL " +
                 PROCEDURE_NAME_PLACEHOLDER +
-                "(?, ?, ?, ?, ?, ?)";  // 6 ? placeholders: positions 1-5 IN, 6 OUT
+                " (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)"; // 6 ? placeholders: positions 1-5 IN, 6 OUT
     }
+
     @Override
     public String getMaxLsnQuery() {
         return getMaxLsn;
@@ -131,6 +132,7 @@ public class LuwPlatform implements Db2PlatformAdapter {
     public String getUpdatePruneSetForPruneSetName() {
         return updatePruneSetForPruneSetName;
     }
+
     @Override
     public String getUpdatePruneSetProcedureCall(final String procedureName) {
         return updatePruneSetProcedureCall.replace(PROCEDURE_NAME_PLACEHOLDER, procedureName);

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -20,7 +20,7 @@ public class LuwPlatform implements Db2PlatformAdapter {
     private final String getListOfNewCdcEnabledTables;
     private static final String STATEMENTS_PLACEHOLDER = "#";
     private final String getEndLsnForSecondsFromLsn;
-    private final String updatePurgeSetForPurgeSetName;
+    private final String updatePruneSetForPruneSetName;
 
     public LuwPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -76,8 +76,8 @@ public class LuwPlatform implements Db2PlatformAdapter {
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
 
-        this.updatePurgeSetForPurgeSetName = "" +
-             "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PURGE_SET " +
+        this.updatePruneSetForPruneSetName = "" +
+                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PRUNE_SET " +
                 "SET " +
                 "  SYNCHPOINT = ?, " +
                 "  SYNCHTIME = ? " +
@@ -113,8 +113,8 @@ public class LuwPlatform implements Db2PlatformAdapter {
     }
 
     @Override
-    public String getUpdatePurgeSetForPurgeSetName() {
-        return updatePurgeSetForPurgeSetName;
+    public String getUpdatePruneSetForPruneSetName() {
+        return updatePruneSetForPruneSetName;
     }
 
 }

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -21,6 +21,8 @@ public class LuwPlatform implements Db2PlatformAdapter {
     private static final String STATEMENTS_PLACEHOLDER = "#";
     private final String getEndLsnForSecondsFromLsn;
     private final String updatePruneSetForPruneSetName;
+    private final String updatePruneSetProcedureCall;
+    private static final String PROCEDURE_NAME_PLACEHOLDER = "{{PROCEDURE_NAME}}";
 
     public LuwPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -85,8 +87,21 @@ public class LuwPlatform implements Db2PlatformAdapter {
                 "   APPLY_QUAL = ? AND " +
                 "   SET_NAME = ? AND " +
                 "   TARGET_SERVER = ?;";
-    }
 
+    /*
+            Implementation must have this interface:
+                IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+                IN P_SYNCHTIME TIMESTAMP,
+                IN P_APPLY_QUAL VARCHAR(18),
+                IN P_SET_NAME VARCHAR(18),
+                IN P_TARGET_SERVER VARCHAR(18),
+                OUT P_UPDATED_COUNT INT
+         */
+        this.updatePruneSetProcedureCall = "" +
+                "CALL " +
+                PROCEDURE_NAME_PLACEHOLDER +
+                "(?, ?, ?, ?, ?, ?)";  // 6 ? placeholders: positions 1-5 IN, 6 OUT
+    }
     @Override
     public String getMaxLsnQuery() {
         return getMaxLsn;
@@ -116,5 +131,8 @@ public class LuwPlatform implements Db2PlatformAdapter {
     public String getUpdatePruneSetForPruneSetName() {
         return updatePruneSetForPruneSetName;
     }
-
+    @Override
+    public String getUpdatePruneSetProcedureCall(final String procedureName) {
+        return updatePruneSetProcedureCall.replace(PROCEDURE_NAME_PLACEHOLDER, procedureName);
+    }
 }

--- a/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/LuwPlatform.java
@@ -20,6 +20,7 @@ public class LuwPlatform implements Db2PlatformAdapter {
     private final String getListOfNewCdcEnabledTables;
     private static final String STATEMENTS_PLACEHOLDER = "#";
     private final String getEndLsnForSecondsFromLsn;
+    private final String updatePurgeSetForPurgeSetName;
 
     public LuwPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -75,6 +76,15 @@ public class LuwPlatform implements Db2PlatformAdapter {
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
 
+        this.updatePurgeSetForPurgeSetName = "" +
+             "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PURGE_SET " +
+                "SET " +
+                "  SYNCHPOINT = ?, " +
+                "  SYNCHTIME = ? " +
+                "WHERE " +
+                "   APPLY_QUAL = ? AND " +
+                "   SET_NAME = ? AND " +
+                "   TARGET_SERVER = ?;";
     }
 
     @Override
@@ -101,4 +111,10 @@ public class LuwPlatform implements Db2PlatformAdapter {
     public String getEndLsnForSecondsFromLsnQuery() {
         return getEndLsnForSecondsFromLsn;
     }
+
+    @Override
+    public String getUpdatePurgeSetForPurgeSetName() {
+        return updatePurgeSetForPurgeSetName;
+    }
+
 }

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -19,6 +19,7 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     private final String getListOfCdcEnabledTables;
     private final String getListOfNewCdcEnabledTables;
     private final String getEndLsnForSecondsFromLsn;
+    private final String updatePurgeSetForPurgeSetName;
 
     public ZOsPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -83,6 +84,16 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 "ORDER BY " +
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
+
+        this.updatePurgeSetForPurgeSetName = "" +
+                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PURGE_SET " +
+                "SET " +
+                "  SYNCHPOINT = ?, " +
+                "  SYNCHTIME = ? " +
+                "WHERE " +
+                "   APPLY_QUAL = ? AND " +
+                "   SET_NAME = ? AND " +
+                "   TARGET_SERVER = ?;";
     }
 
     @Override
@@ -108,5 +119,10 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     @Override
     public String getEndLsnForSecondsFromLsnQuery() {
         return getEndLsnForSecondsFromLsn;
+    }
+
+    @Override
+    public String getUpdatePurgeSetForPurgeSetName() {
+        return updatePurgeSetForPurgeSetName;
     }
 }

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -19,7 +19,7 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     private final String getListOfCdcEnabledTables;
     private final String getListOfNewCdcEnabledTables;
     private final String getEndLsnForSecondsFromLsn;
-    private final String updatePurgeSetForPurgeSetName;
+    private final String updatePruneSetForPruneSetName;
 
     public ZOsPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -85,8 +85,8 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
 
-        this.updatePurgeSetForPurgeSetName = "" +
-                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PURGE_SET " +
+        this.updatePruneSetForPruneSetName = "" +
+                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PRUNE_SET " +
                 "SET " +
                 "  SYNCHPOINT = ?, " +
                 "  SYNCHTIME = ? " +
@@ -122,7 +122,7 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     }
 
     @Override
-    public String getUpdatePurgeSetForPurgeSetName() {
-        return updatePurgeSetForPurgeSetName;
+    public String getUpdatePruneSetForPruneSetName() {
+        return updatePruneSetForPruneSetName;
     }
 }

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -87,15 +87,16 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 "       uow.IBMSNAP_COMMITSEQ DESC " +
                 "LIMIT 1";
 
-        this.updatePruneSetForPruneSetName = "" +
-                "UPDATE " + connectorConfig.getCdcControlSchema() + ".IBMSNAP_PRUNE_SET " +
-                "SET " +
-                "  SYNCHPOINT = ?, " +
-                "  SYNCHTIME = ? " +
-                "WHERE " +
-                "   APPLY_QUAL = ? AND " +
-                "   SET_NAME = ? AND " +
-                "   TARGET_SERVER = ?;";
+        this.updatePruneSetForPruneSetName = """
+                UPDATE %s.IBMSNAP_PRUNE_SET
+                SET
+                    SYNCHPOINT = ?,
+                    SYNCHTIME = ?
+                WHERE
+                    APPLY_QUAL = ? AND
+                    SET_NAME = ? AND
+                    TARGET_SERVER = ?;
+                """.formatted(connectorConfig.getCdcControlSchema());
 
         /*
          * Implementation must have this interface:
@@ -106,10 +107,9 @@ public class ZOsPlatform implements Db2PlatformAdapter {
          * IN P_TARGET_SERVER VARCHAR(18),
          * OUT P_UPDATED_COUNT INT
          */
-        this.updatePruneSetProcedureCall = "" +
-                "CALL " +
-                PROCEDURE_NAME_PLACEHOLDER +
-                " (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)"; // 6 ? placeholders: positions 1-5 IN, 6 OUT
+        this.updatePruneSetProcedureCall = """
+                CALL %s (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)
+                """.formatted(PROCEDURE_NAME_PLACEHOLDER); // 6 ? placeholders: positions 1-5 IN, 6 OUT
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -98,19 +98,18 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 "   TARGET_SERVER = ?;";
 
         /*
-            Implementation must have this interface:
-                IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
-                IN P_SYNCHTIME TIMESTAMP,
-                IN P_APPLY_QUAL VARCHAR(18),
-                IN P_SET_NAME VARCHAR(18),
-                IN P_TARGET_SERVER VARCHAR(18),
-                OUT P_UPDATED_COUNT INT
+         * Implementation must have this interface:
+         * IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+         * IN P_SYNCHTIME TIMESTAMP,
+         * IN P_APPLY_QUAL VARCHAR(18),
+         * IN P_SET_NAME VARCHAR(18),
+         * IN P_TARGET_SERVER VARCHAR(18),
+         * OUT P_UPDATED_COUNT INT
          */
         this.updatePruneSetProcedureCall = "" +
                 "CALL " +
                 PROCEDURE_NAME_PLACEHOLDER +
-                "(?, ?, ?, ?, ?, ?)";  // 6 ? placeholders: positions 1-5 IN, 6 OUT
-
+                " (P_SYNCHPOINT=>?, P_SYNCHTIME=>?, P_APPLY_QUAL=>?, P_SET_NAME=>?, P_TARGET_SERVER=>?, P_UPDATED_COUNT=>?)"; // 6 ? placeholders: positions 1-5 IN, 6 OUT
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
+++ b/src/main/java/io/debezium/connector/db2/platform/ZOsPlatform.java
@@ -20,6 +20,8 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     private final String getListOfNewCdcEnabledTables;
     private final String getEndLsnForSecondsFromLsn;
     private final String updatePruneSetForPruneSetName;
+    private final String updatePruneSetProcedureCall;
+    private static final String PROCEDURE_NAME_PLACEHOLDER = "{{PROCEDURE_NAME}}";
 
     public ZOsPlatform(Db2ConnectorConfig connectorConfig) {
 
@@ -94,6 +96,21 @@ public class ZOsPlatform implements Db2PlatformAdapter {
                 "   APPLY_QUAL = ? AND " +
                 "   SET_NAME = ? AND " +
                 "   TARGET_SERVER = ?;";
+
+        /*
+            Implementation must have this interface:
+                IN P_SYNCHPOINT VARCHAR () For BIT DATA(16),
+                IN P_SYNCHTIME TIMESTAMP,
+                IN P_APPLY_QUAL VARCHAR(18),
+                IN P_SET_NAME VARCHAR(18),
+                IN P_TARGET_SERVER VARCHAR(18),
+                OUT P_UPDATED_COUNT INT
+         */
+        this.updatePruneSetProcedureCall = "" +
+                "CALL " +
+                PROCEDURE_NAME_PLACEHOLDER +
+                "(?, ?, ?, ?, ?, ?)";  // 6 ? placeholders: positions 1-5 IN, 6 OUT
+
     }
 
     @Override
@@ -124,5 +141,10 @@ public class ZOsPlatform implements Db2PlatformAdapter {
     @Override
     public String getUpdatePruneSetForPruneSetName() {
         return updatePruneSetForPruneSetName;
+    }
+
+    @Override
+    public String getUpdatePruneSetProcedureCall(final String procedureName) {
+        return updatePruneSetProcedureCall.replace(PROCEDURE_NAME_PLACEHOLDER, procedureName);
     }
 }

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1138,22 +1139,27 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
     @Test
     @FixFor("DBZ-1843")
     public void shouldUpdatePruneSetTableAndControlPrune() throws Exception {
-        final String targetTableSchemaName = "DB2INST1";
-        final String targetTableName = "TABLEA";
-        final String applyQual = "AQ00";
-        final String setName = "SET_NAME";
-        final String targetSystem = "TARGET_SYSTEM";
+        final String sourceTableSchemaName = "DB2INST1";
+        final String sourceTableName = "TABLEA";
+        final String applyQual = "KAFKAQUAL";
+        final String setName = "SET001";
+        final String targetSystem = "KAFKA";
         final int pruneIntervalInSec = 10;
 
+        final Map<String, String> pruneControlCapInfoMap = new HashMap<>();
+
         final int STARTING_ID = 100;
+        int currentId = STARTING_ID;
         final int ATTEMPTS_MAX = 10;
+        final int NUM_TO_INSERT = 10;
+
         final Configuration config = TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_IND, true)
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL, applyQual)
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME, setName)
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER, targetSystem)
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT, true)
-                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, targetTableSchemaName + "." + targetTableName)
+                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, sourceTableSchemaName + "." + sourceTableName)
                 .build();
 
         start(Db2Connector.class, config);
@@ -1161,62 +1167,113 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         // Wait for snapshot completion
         consumeRecordsByTopic(1);
-        // Establish Pruning Setup
-        final Map<String, String> controlTableInfoMap = TestHelper.prepareToPruneControlAndReinitializeCap(
-                targetTableSchemaName, targetTableName, applyQual, setName, targetSystem, pruneIntervalInSec);
+        TestHelper.setCapParamsPruneInterval(10);
         TestHelper.enableDbCdc(connection);
+        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A' WHERE SOURCE_OWNER = 'DB2INST1'");
         TestHelper.refreshAndWait(connection);
+        // Establish Pruning Setup
+        TestHelper.getChangeTablesForPhysicalTableFromRegistrationTable(
+                sourceTableSchemaName, sourceTableName, pruneControlCapInfoMap);
+        TestHelper.checkAndCorrectPhysicalChangeTablesBetweenRegistrationAndPrunectlForTable(
+                sourceTableSchemaName, sourceTableName, pruneControlCapInfoMap);
+        TestHelper.insertRecordToPruneSetTable(
+                targetSystem, applyQual, setName);
+        TestHelper.setOldSynchpointOnRegistrationTable(
+                sourceTableSchemaName, sourceTableName);
+        String mapId = TestHelper.getPruneCtlRecordsForTable(
+                sourceTableSchemaName, sourceTableName, targetSystem, applyQual, setName, pruneControlCapInfoMap);
+        TestHelper.signalCapRestartForMapId(mapId);
+        TestHelper.validatePruneReadinessForTable(
+                sourceTableSchemaName, sourceTableName, targetSystem, applyQual, setName);
+
         // Know where the pruning was at the beginning
         final Lsn startingPruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
+
         logger.info("Starting Prune LSN: {}", startingPruneLsn);
 
-        boolean receivedEventMatchingInsert = false;
-        for (int i = STARTING_ID; i < (ATTEMPTS_MAX + STARTING_ID); i++) {
-            final Lsn beforeInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
-                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
-                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
-            logger.info("Before Insert Change Table Last LSN: {}", beforeInsertChangeTableLastLsn);
-            logger.info("Inserting record with id {}", i);
+        final Lsn beforeInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+        final int numRecordsOnChangeTableBefore = TestHelper.getSizeOfChangeTable(
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+        logger.info("Before Insert Change Table size: {}", numRecordsOnChangeTableBefore);
+        logger.info("Before Insert Change Table Last LSN: {}", beforeInsertChangeTableLastLsn);
+        for (int j = 0; j < NUM_TO_INSERT; j++) {
+            logger.info("Inserting record with id {}", currentId);
             connection.execute(
-                    "INSERT INTO tablea VALUES(" + i + ", 'b')");
-            logger.info("Inserted record with id {}", i);
+                    "INSERT INTO tablea VALUES(" + currentId + ", 'b')");
+            logger.info("Inserted record with id {}", currentId);
             connection.commit();
-            TestHelper.refreshAndWait(connection);
-            SourceRecords sourceRecords = consumeRecordsByTopic(1);
-            sourceRecords.print();
-            for (String topicName : sourceRecords.topics()) {
-                logger.info("Topic: {}", topicName);
-            }
-            assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(1);
-            receivedEventMatchingInsert = true;
-            final Lsn afterInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
-                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
-                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
-            logger.info("After Insert Change Table Last LSN: {}", afterInsertChangeTableLastLsn);
-            final Lsn afterInsertChangeTableLastLsnDecremented = afterInsertChangeTableLastLsn.decrement();
-            // Wait to see if the prune point is moved forward. It won't move unless there are new changes
-            // to potentially reflect - that is why this is in a for.
-            Awaitility.await().atMost(pruneIntervalInSec, TimeUnit.SECONDS).until(() -> {
-                final Lsn pruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
-                logger.info("Prune LSN: {}", pruneLsn);
-                return pruneLsn.equals(afterInsertChangeTableLastLsnDecremented);
-            });
-            SourceRecord record = (SourceRecord) sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA").get(0).value();
-            logger.info("Expected key {}, found key {}", i, ((Struct) record.key()).get("ID"));
-            logger.info("Expected value {}, found value {}", i, ((Struct) record.value()).get("ID"));
+            currentId++;
         }
+        SourceRecords sourceRecords = consumeRecordsByTopic(NUM_TO_INSERT);
 
-        final Lsn endingPruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
-        logger.info("Ending Prune LSN: {}", endingPruneLsn);
+        final int numRecordsOnChangeTableAfter = TestHelper.getSizeOfChangeTable(
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+        logger.info("After Insert Change Table size: {}", numRecordsOnChangeTableAfter);
 
-        // assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(RECORDS_PER_TABLE);
+        final Lsn afterInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+        logger.info("After Insert Change Table Last LSN: {}", afterInsertChangeTableLastLsn);
+        final Lsn afterInsertChangeTableLastLsnDecremented = afterInsertChangeTableLastLsn.decrement();
+        // Wait to see if the prune point is moved forward. It won't move unless there are new changes
+        // to potentially reflect. This shows that the prune set update table is being updated.
+        Awaitility.await().pollInterval(1, TimeUnit.SECONDS).atMost(pruneIntervalInSec * 2, TimeUnit.SECONDS).until(() -> {
+            TestHelper.createDBRecords(5);
+            final Lsn pruneLsnAfterEvent = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
+            int comparison = afterInsertChangeTableLastLsnDecremented.compareTo(
+                    pruneLsnAfterEvent);
+            if (comparison < 0) {
+                logger.info("Prune LSN now: {} is the later than as it was following the initial changes: {}.",
+                        pruneLsnAfterEvent, afterInsertChangeTableLastLsnDecremented);
+                return true;
+            }
+            else if (comparison == 0) {
+                logger.info("Prune LSN now: {} is the same as it was following the initial changes: {}.",
+                        pruneLsnAfterEvent, afterInsertChangeTableLastLsnDecremented);
+                return false;
+            }
+            else {
+                logger.info("Prune LSN now: {} is the earlier than as it was following the initial changes: {}.",
+                        pruneLsnAfterEvent, afterInsertChangeTableLastLsnDecremented);
+                return false;
+            }
+        });
+        int priorChangeTableSize = TestHelper.getSizeOfChangeTable(
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+        /*
+         * This test is to see if the prune from the Capture agent is reading the prune set table and pruning.
+         */
+        TestHelper.createDBRecords(100);
+        Awaitility.await().pollInterval(1, TimeUnit.SECONDS).atMost(600, TimeUnit.SECONDS).until(() -> {
+            int currentChangeTableSize = TestHelper.getSizeOfChangeTable(
+                    pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                    pruneControlCapInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
 
-        // int expectedKey = STARTING_ID;
-        // for (SourceRecord record : sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")) {
-        // logger.info("Expected key {}, found key {}", expectedKey, ((Struct) record.key()).get("ID"));
-        // assertThat(((Struct) record.key()).get("ID").equals(expectedKey));
-        // expectedKey++;
-        // }
+            logger.info("Change Table size: {} while it was before {}", currentChangeTableSize, numRecordsOnChangeTableAfter);
+            TestHelper.createDBRecords(1); // Keep adding one so there is a cycle to potentially allow a prune update
+            int comparison = Integer.compare(priorChangeTableSize, currentChangeTableSize);
+            if (comparison < 0) {
+                logger.info("The prior size {} is less than the current size {}. This means a prune has not recently occurred.",
+                        priorChangeTableSize, currentChangeTableSize);
+                TestHelper.readCapTrace(10);
+                return false;
+            }
+            else if (comparison == 0) {
+                logger.info("The prior size {} is the same as the current size {}. This means a prune has not recently occurred.",
+                        priorChangeTableSize, currentChangeTableSize);
+                return false;
+            }
+            else {
+                logger.info("The prior size {} greater than the current size {}. This means a prune has recently occurred.",
+                        priorChangeTableSize, currentChangeTableSize);
+                return true;
+            }
+        });
 
         stopConnector();
     }
@@ -1224,4 +1281,5 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
     }
+
 }

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -1135,21 +1137,16 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor("DBZ-1843")
-    public void shouldUpdatePruneSetTable() throws Exception {
+    public void shouldUpdatePruneSetTableAndControlPrune() throws Exception {
         final String targetTableSchemaName = "DB2INST1";
         final String targetTableName = "TABLEA";
         final String applyQual = "AQ00";
         final String setName = "SET_NAME";
         final String targetSystem = "TARGET_SYSTEM";
-        final String controlTableSchemaName = "ASNCDC";
-        final String pruneSetTableName = controlTableSchemaName + ".IBMSNAP_PRUNE_SET";
-        final String pruneCtlTableName = controlTableSchemaName + ".IBMSNAP_PRUNECTL";
-        final String capParamsTableName = controlTableSchemaName + ".IBMSNAP_CAPPARAMS";
-        final String lsnZeroString = "0x00000000000000000000000000000000";
-        final String epochTimestamp = "1970-01-01 00:00:00.00";
+        final int pruneIntervalInSec = 10;
 
         final int STARTING_ID = 100;
-        final int RECORDS_PER_TABLE = 10;
+        final int ATTEMPTS_MAX = 10;
         final Configuration config = TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_IND, true)
                 .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL, applyQual)
@@ -1164,39 +1161,62 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         // Wait for snapshot completion
         consumeRecordsByTopic(1);
-
-        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A' WHERE SOURCE_OWNER = 'DB2INST1'");
-        connection.execute("INSERT INTO " + pruneCtlTableName + " " +
-                        "(           TARGET_SERVER,          TARGET_OWNER,                    TARGET_TABLE,       SYNCHTIME, SYNCHPOINT, SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, PHYS_CHANGE_TABLE, MAP_ID)\n" +
-                        "VALUES('" + targetSystem + "', '" + targetTableSchemaName + "', '" + targetTableName + "', '2026-04-29 11:22:48.825', 0x00000000000182EA75EA000000000000, 'DSN81310', 'EMP', 0, 'AQ00              ', 'SET01             ', 'DBD1LOC           ', 8, 'DBD1LOC ', 'DSN81310', 'CDEMP', '0');)
-        connection.execute("UPDATE ASNCDC.IBMSNAP_PRUNE_SET")
+        // Establish Pruning Setup
+        final Map<String, String> controlTableInfoMap = TestHelper.prepareToPruneControlAndReinitializeCap(
+                targetTableSchemaName, targetTableName, applyQual, setName, targetSystem, pruneIntervalInSec);
         TestHelper.enableDbCdc(connection);
-
         TestHelper.refreshAndWait(connection);
+        // Know where the pruning was at the beginning
+        final Lsn startingPruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
+        logger.info("Starting Prune LSN: {}", startingPruneLsn);
 
-        for (int i = STARTING_ID; i < (RECORDS_PER_TABLE + STARTING_ID); i++) {
+        boolean receivedEventMatchingInsert = false;
+        for (int i = STARTING_ID; i < (ATTEMPTS_MAX + STARTING_ID); i++) {
+            final Lsn beforeInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
+                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+            logger.info("Before Insert Change Table Last LSN: {}", beforeInsertChangeTableLastLsn);
             logger.info("Inserting record with id {}", i);
             connection.execute(
                     "INSERT INTO tablea VALUES(" + i + ", 'b')");
             logger.info("Inserted record with id {}", i);
             connection.commit();
+            TestHelper.refreshAndWait(connection);
+            SourceRecords sourceRecords = consumeRecordsByTopic(1);
+            sourceRecords.print();
+            for (String topicName : sourceRecords.topics()) {
+                logger.info("Topic: {}", topicName);
+            }
+            assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(1);
+            receivedEventMatchingInsert = true;
+            final Lsn afterInsertChangeTableLastLsn = TestHelper.getLastChangeLsnForChangeTable(
+                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_OWNER),
+                    controlTableInfoMap.get(TestHelper.MAP_KEY_CHANGE_TABLE_NAME));
+            logger.info("After Insert Change Table Last LSN: {}", afterInsertChangeTableLastLsn);
+            final Lsn afterInsertChangeTableLastLsnDecremented = afterInsertChangeTableLastLsn.decrement();
+            // Wait to see if the prune point is moved forward. It won't move unless there are new changes
+            // to potentially reflect - that is why this is in a for.
+            Awaitility.await().atMost(pruneIntervalInSec, TimeUnit.SECONDS).until(() -> {
+                final Lsn pruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
+                logger.info("Prune LSN: {}", pruneLsn);
+                return pruneLsn.equals(afterInsertChangeTableLastLsnDecremented);
+            });
+            SourceRecord record = (SourceRecord) sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA").get(0).value();
+            logger.info("Expected key {}, found key {}", i, ((Struct) record.key()).get("ID"));
+            logger.info("Expected value {}, found value {}", i, ((Struct) record.value()).get("ID"));
         }
-        TestHelper.refreshAndWait(connection);
 
-        SourceRecords sourceRecords = consumeRecordsByTopic(RECORDS_PER_TABLE);
-        sourceRecords.print();
-        for (String topicName : sourceRecords.topics()) {
-            logger.info("Topic: {}", topicName);
-        }
+        final Lsn endingPruneLsn = TestHelper.getLsnSyncPointForPruneSet(applyQual, setName, targetSystem);
+        logger.info("Ending Prune LSN: {}", endingPruneLsn);
 
-        assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(RECORDS_PER_TABLE);
+        // assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(RECORDS_PER_TABLE);
 
-        int expectedKey = STARTING_ID;
-        for (SourceRecord record : sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")) {
-            logger.info("Expected key {}, found key {}", expectedKey, ((Struct) record.key()).get("ID"));
-            assertThat(((Struct) record.key()).get("ID").equals(expectedKey));
-            expectedKey++;
-        }
+        // int expectedKey = STARTING_ID;
+        // for (SourceRecord record : sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")) {
+        // logger.info("Expected key {}, found key {}", expectedKey, ((Struct) record.key()).get("ID"));
+        // assertThat(((Struct) record.key()).get("ID").equals(expectedKey));
+        // expectedKey++;
+        // }
 
         stopConnector();
     }

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -1133,6 +1133,74 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
         stopConnector();
     }
 
+    @Test
+    @FixFor("DBZ-1843")
+    public void shouldUpdatePruneSetTable() throws Exception {
+        final String targetTableSchemaName = "DB2INST1";
+        final String targetTableName = "TABLEA";
+        final String applyQual = "AQ00";
+        final String setName = "SET_NAME";
+        final String targetSystem = "TARGET_SYSTEM";
+        final String controlTableSchemaName = "ASNCDC";
+        final String pruneSetTableName = controlTableSchemaName + ".IBMSNAP_PRUNE_SET";
+        final String pruneCtlTableName = controlTableSchemaName + ".IBMSNAP_PRUNECTL";
+        final String capParamsTableName = controlTableSchemaName + ".IBMSNAP_CAPPARAMS";
+        final String lsnZeroString = "0x00000000000000000000000000000000";
+        final String epochTimestamp = "1970-01-01 00:00:00.00";
+
+        final int STARTING_ID = 100;
+        final int RECORDS_PER_TABLE = 10;
+        final Configuration config = TestHelper.defaultConfig()
+                .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_IND, true)
+                .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL, applyQual)
+                .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME, setName)
+                .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER, targetSystem)
+                .with(Db2ConnectorConfig.UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT, true)
+                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, targetTableSchemaName + "." + targetTableName)
+                .build();
+
+        start(Db2Connector.class, config);
+        assertConnectorIsRunning();
+
+        // Wait for snapshot completion
+        consumeRecordsByTopic(1);
+
+        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A' WHERE SOURCE_OWNER = 'DB2INST1'");
+        connection.execute("INSERT INTO " + pruneCtlTableName + " " +
+                        "(           TARGET_SERVER,          TARGET_OWNER,                    TARGET_TABLE,       SYNCHTIME, SYNCHPOINT, SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, PHYS_CHANGE_TABLE, MAP_ID)\n" +
+                        "VALUES('" + targetSystem + "', '" + targetTableSchemaName + "', '" + targetTableName + "', '2026-04-29 11:22:48.825', 0x00000000000182EA75EA000000000000, 'DSN81310', 'EMP', 0, 'AQ00              ', 'SET01             ', 'DBD1LOC           ', 8, 'DBD1LOC ', 'DSN81310', 'CDEMP', '0');)
+        connection.execute("UPDATE ASNCDC.IBMSNAP_PRUNE_SET")
+        TestHelper.enableDbCdc(connection);
+
+        TestHelper.refreshAndWait(connection);
+
+        for (int i = STARTING_ID; i < (RECORDS_PER_TABLE + STARTING_ID); i++) {
+            logger.info("Inserting record with id {}", i);
+            connection.execute(
+                    "INSERT INTO tablea VALUES(" + i + ", 'b')");
+            logger.info("Inserted record with id {}", i);
+            connection.commit();
+        }
+        TestHelper.refreshAndWait(connection);
+
+        SourceRecords sourceRecords = consumeRecordsByTopic(RECORDS_PER_TABLE);
+        sourceRecords.print();
+        for (String topicName : sourceRecords.topics()) {
+            logger.info("Topic: {}", topicName);
+        }
+
+        assertThat(sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")).hasSize(RECORDS_PER_TABLE);
+
+        int expectedKey = STARTING_ID;
+        for (SourceRecord record : sourceRecords.recordsForTopic("testdb.DB2INST1.TABLEA")) {
+            logger.info("Expected key {}, found key {}", expectedKey, ((Struct) record.key()).get("ID"));
+            assertThat(((Struct) record.key()).get("ID").equals(expectedKey));
+            expectedKey++;
+        }
+
+        stopConnector();
+    }
+
     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
     }

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -27,11 +27,11 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -1137,7 +1137,7 @@ public class Db2ConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-1843")
+    @FixFor("debezium/dbz#1843")
     public void shouldUpdatePruneSetTableAndControlPrune() throws Exception {
         final String sourceTableSchemaName = "DB2INST1";
         final String sourceTableName = "TABLEA";

--- a/src/test/java/io/debezium/connector/db2/util/TestHelper.java
+++ b/src/test/java/io/debezium/connector/db2/util/TestHelper.java
@@ -12,10 +12,15 @@ import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -32,6 +37,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.ConfigurationNames;
 import io.debezium.connector.db2.Db2Connection;
 import io.debezium.connector.db2.Db2ConnectorConfig;
+import io.debezium.connector.db2.Lsn;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Clock;
@@ -46,6 +52,16 @@ public class TestHelper {
     public static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();
     public static final String TEST_DATABASE = "testdb";
     public static final int WAIT_FOR_CDC = 3 * 5000;
+    public static final String CONTROL_TABLE_SCHEMA_NAME = "ASNCDC";
+    public static final String PRUNE_SET_TABLE_NAME = "IBMSNAP_PRUNE_SET";
+    public static final String PRUNE_CTL_TABLE_NAME = "IBMSNAP_PRUNCNTL";
+    public static final String REGISTER_CTL_TABLE_NAME = "IBMSNAP_REGISTER";
+    public static final String CAP_PARAMS_TABLE_NAME = "IBMSNAP_CAPPARMS";
+    public static final String CAP_SIGNAL_TABLE_NAME = "IBMSNAP_SIGNAL";
+    public static final String LSN_ZERO_STRING = "0x0000000000000000";
+    public static final Lsn LSN_FROM_ZERO_STRING = Lsn.valueOf(LSN_ZERO_STRING);
+    public static final String MAP_KEY_CHANGE_TABLE_OWNER = "MAP_KEY_CHANGE_TABLE_OWNER";
+    public static final String MAP_KEY_CHANGE_TABLE_NAME = "MAP_KEY_CHANGE_TABLE_NAME";
 
     /**
      * Key for schema parameter used to store a source column's type name.
@@ -297,5 +313,227 @@ public class TestHelper {
                 }
             });
         }
+    }
+
+    public static Map<String, String> prepareToPruneControlAndReinitializeCap(
+                                                                              final String targetTableSchemaName,
+                                                                              final String targetTableName,
+                                                                              final String applyQual,
+                                                                              final String setName,
+                                                                              final String targetSystem,
+                                                                              final int pruneIntervalInSec) {
+
+        final Map<String, String> pruneControlAndReinitializeCapMap = new HashMap<>();
+        final String mapId = "1000";
+
+        final AtomicReference<String> physChangeOwner = new AtomicReference<>();
+        final AtomicReference<String> physChangeTable = new AtomicReference<>();
+
+        try {
+            final Db2Connection conn = testConnection();
+            { // CapParams PruneInterval Block
+                LOGGER.info("Setting PruneInterval to {} seconds", pruneIntervalInSec);
+                conn.prepareUpdate(
+                        "UPDATE " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_PARAMS_TABLE_NAME + "\n" +
+                                "SET PRUNE_INTERVAL = ?",
+                        ps -> {
+                            ps.setInt(1, pruneIntervalInSec);
+                            ps.execute();
+                        });
+                conn.commit();
+            } // CapParams PruneInterval Block
+            { // Get Physical Change Table from Register Block
+                LOGGER.info("Getting Physical Change Table from Register Block");
+                conn.prepareQuery(
+                        "SELECT PHYS_CHANGE_OWNER, PHYS_CHANGE_TABLE \n" +
+                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + "\n" +
+                                "WHERE SOURCE_OWNER = ? \n" +
+                                "AND SOURCE_TABLE = ?",
+                        ps -> {
+                            ps.setString(1, targetTableSchemaName);
+                            ps.setString(2, targetTableName);
+                        },
+                        rs -> {
+                            while (rs.next()) {
+                                physChangeOwner.set(rs.getString("PHYS_CHANGE_OWNER"));
+                                physChangeTable.set(rs.getString("PHYS_CHANGE_TABLE"));
+                            }
+                        });
+                LOGGER.info("PhysChangeOwner: {}, PhysChangeTable: {}", physChangeOwner, physChangeTable);
+                pruneControlAndReinitializeCapMap.put(MAP_KEY_CHANGE_TABLE_OWNER, physChangeOwner.get());
+                pruneControlAndReinitializeCapMap.put(MAP_KEY_CHANGE_TABLE_NAME, physChangeTable.get());
+            } // Get Physical Change Table from Register Block
+            { // Truncate PruneCtl Block
+                LOGGER.info("Truncating PruneCtl Block");
+                conn.execute("TRUNCATE TABLE " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " IMMEDIATE");
+                conn.commit();
+            } // Truncate PruneCtl Block
+            { // PruneCtl Block
+                LOGGER.info("Setting PruneCtl Block");
+
+                conn.prepareUpdate(
+                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " (" +
+                                "TARGET_SERVER, TARGET_OWNER, TARGET_TABLE, SYNCHTIME, SYNCHPOINT, " +
+                                "SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, " +
+                                "CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, " +
+                                "PHYS_CHANGE_TABLE, MAP_ID) " +
+                                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        ps -> {
+                            ps.setString(1, targetSystem);
+                            ps.setString(2, targetTableSchemaName);
+                            ps.setString(3, targetTableName);
+                            ps.setTimestamp(4, Timestamp.from(Instant.EPOCH));
+                            ps.setBytes(5, LSN_FROM_ZERO_STRING.getBinary());
+                            ps.setString(6, targetTableSchemaName);
+                            ps.setString(7, targetTableName);
+                            ps.setShort(8, Short.parseShort("0"));
+                            ps.setString(9, applyQual);
+                            ps.setString(10, setName);
+                            ps.setString(11, "CTL_SER");
+                            ps.setShort(12, Short.parseShort("8"));
+                            ps.setString(13, "CTLALAS");
+                            ps.setString(14, physChangeOwner.get());
+                            ps.setString(15, physChangeTable.get());
+                            ps.setString(16, mapId);
+                            ps.execute();
+                        });
+                conn.commit();
+            } // PruneCtl Block
+            { // Truncate PruneSet Block
+                LOGGER.info("Truncating PruneSet Block");
+                conn.execute("TRUNCATE TABLE " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " IMMEDIATE");
+                conn.commit();
+            } // Truncate PruneSet Block
+            { // Populate PruneSet Block
+                LOGGER.info("Populating PruneSet Block");
+                conn.prepareUpdate(
+                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + "\n" +
+                                "(TARGET_SERVER, APPLY_QUAL, SET_NAME, SYNCHTIME, SYNCHPOINT)\n" +
+                                "VALUES(?,?,?,?,?)",
+                        ps -> {
+                            ps.setString(1, targetSystem);
+                            ps.setString(2, applyQual);
+                            ps.setString(3, setName);
+                            ps.setTimestamp(4, Timestamp.from(Instant.EPOCH));
+                            ps.setBytes(5, hexStringToByteArray(LSN_ZERO_STRING));
+                            ps.execute();
+                        });
+                conn.commit();
+            } // Populate PruneSet Block
+            { // CapSignal - Restart Cap for MapId Block
+                LOGGER.info("Restarting Cap for MapId Block");
+                conn.prepareUpdate(
+                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_SIGNAL_TABLE_NAME + "\n" +
+                                "(SIGNAL_TYPE, SIGNAL_SUBTYPE, SIGNAL_INPUT_IN, SIGNAL_STATE)\n" +
+                                "VALUES ('CMD', 'CAPSTART', ?, 'P')",
+                        ps -> {
+                            ps.setString(1, mapId);
+                            ps.execute();
+                        });
+                conn.commit();
+            } // CapSignal - Restart Cap for MapId Block
+            { // Confirm Prune Data is in Place Block
+                LOGGER.info("Confirming Prune Data is in Place Block");
+                conn.prepareQuery(
+                        "SELECT ips.TARGET_SERVER, ips.synchpoint, ips.SET_NAME, ips.TARGET_SERVER, ips.APPLY_QUAL, " +
+                                "ip.PHYS_CHANGE_OWNER, ip.PHYS_CHANGE_TABLE \n" +
+                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " ips, \n" +
+                                CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " ip \n" +
+                                "WHERE ips.SET_NAME = ip.SET_NAME = ?\n" +
+                                "AND ips.TARGET_SERVER = ip.TARGET_SERVER = ?\n" +
+                                "AND ips.APPLY_QUAL = ip.APPLY_QUAL = ?",
+                        ps -> {
+                            ps.setString(1, setName);
+                            ps.setString(2, targetSystem);
+                            ps.setString(3, applyQual);
+                        },
+                        rs -> {
+                            while (rs.next()) {
+                                LOGGER.info("Prune Data record found. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
+                                        "SynchPoint: {}\nPhysChangeOwner: {}\nPhysChangeTable: {}",
+                                        rs.getString("TARGET_SERVER"),
+                                        rs.getString("APPLY_QUAL"),
+                                        rs.getString("SET_NAME"),
+                                        rs.getString("synchpoint"),
+                                        rs.getString("PHYS_CHANGE_OWNER"),
+                                        rs.getString("PHYS_CHANGE_TABLE"));
+                            }
+                        });
+            } // Confirm Prune Data is in Place Block
+        }
+        catch (SQLException e) {
+            System.err.println("SQL Error: " + e.getSQLState() + " " + e.getMessage());
+            e.printStackTrace();
+        }
+        return pruneControlAndReinitializeCapMap;
+    }
+
+    public static Lsn getLsnSyncPointForPruneSet(final String applyQual,
+                                                 final String setName,
+                                                 final String targetSystem) {
+        {
+            final Db2Connection conn = testConnection();
+            LOGGER.info("Getting the current LSN on the table.");
+            AtomicReference<String> lsnString = new AtomicReference<>();
+            try {
+                conn.prepareQuery(
+                        "SELECT SYNCHPOINT \n" +
+                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + "\n" +
+                                "WHERE SET_NAME = ?\n" +
+                                "AND TARGET_SERVER = ?\n" +
+                                "AND APPLY_QUAL = ?",
+                        ps -> {
+                            ps.setString(1, setName);
+                            ps.setString(2, targetSystem);
+                            ps.setString(3, applyQual);
+                        },
+                        rs -> {
+                            while (rs.next()) {
+                                lsnString.set(rs.getString("SYNCHPOINT"));
+
+                            }
+                        });
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+            return Lsn.valueOf(lsnString.get());
+        }
+    }
+
+    public static Lsn getLastChangeLsnForChangeTable(
+                                                     final String changeTableOwner,
+                                                     final String changeTableName) {
+
+        final Db2Connection conn = testConnection();
+        LOGGER.info("Getting the last change LSN for {}.{}", changeTableOwner, changeTableName);
+        AtomicReference<String> lsnString = new AtomicReference<>();
+        try {
+            conn.prepareQuery(
+                    "SELECT IBMSNAP_COMMITSEQ \n" +
+                            "FROM " + changeTableOwner + "." + changeTableName + "\n" +
+                            "ORDER BY IBMSNAP_COMMITSEQ DESC LIMIT 1",
+                    ps -> {
+                    },
+                    rs -> {
+                        while (rs.next()) {
+                            lsnString.set(rs.getString("IBMSNAP_COMMITSEQ"));
+                        }
+                    });
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Lsn.valueOf(lsnString.get());
+    }
+
+    // Helper method to convert hex string to byte array
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+        }
+        return data;
     }
 }

--- a/src/test/java/io/debezium/connector/db2/util/TestHelper.java
+++ b/src/test/java/io/debezium/connector/db2/util/TestHelper.java
@@ -39,6 +39,7 @@ import io.debezium.connector.db2.Db2Connection;
 import io.debezium.connector.db2.Db2ConnectorConfig;
 import io.debezium.connector.db2.Lsn;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;
@@ -55,6 +56,7 @@ public class TestHelper {
     public static final String CONTROL_TABLE_SCHEMA_NAME = "ASNCDC";
     public static final String PRUNE_SET_TABLE_NAME = "IBMSNAP_PRUNE_SET";
     public static final String PRUNE_CTL_TABLE_NAME = "IBMSNAP_PRUNCNTL";
+    public static final String PRUNE_CAP_TRACE_TABLE_NAME = "IBMSNAP_CAPTRACE";
     public static final String REGISTER_CTL_TABLE_NAME = "IBMSNAP_REGISTER";
     public static final String CAP_PARAMS_TABLE_NAME = "IBMSNAP_CAPPARMS";
     public static final String CAP_SIGNAL_TABLE_NAME = "IBMSNAP_SIGNAL";
@@ -62,6 +64,8 @@ public class TestHelper {
     public static final Lsn LSN_FROM_ZERO_STRING = Lsn.valueOf(LSN_ZERO_STRING);
     public static final String MAP_KEY_CHANGE_TABLE_OWNER = "MAP_KEY_CHANGE_TABLE_OWNER";
     public static final String MAP_KEY_CHANGE_TABLE_NAME = "MAP_KEY_CHANGE_TABLE_NAME";
+    public static final String MAP_KEY_PRUNECTL_MAP_ID = "MAP_KEY_PRUNECTL_MAP_ID";
+    private static int currentIdForTestEvents = 1000;
 
     /**
      * Key for schema parameter used to store a source column's type name.
@@ -315,172 +319,20 @@ public class TestHelper {
         }
     }
 
-    public static Map<String, String> prepareToPruneControlAndReinitializeCap(
-                                                                              final String targetTableSchemaName,
-                                                                              final String targetTableName,
-                                                                              final String applyQual,
-                                                                              final String setName,
-                                                                              final String targetSystem,
-                                                                              final int pruneIntervalInSec) {
-
-        final Map<String, String> pruneControlAndReinitializeCapMap = new HashMap<>();
-        final String mapId = "1000";
-
-        final AtomicReference<String> physChangeOwner = new AtomicReference<>();
-        final AtomicReference<String> physChangeTable = new AtomicReference<>();
-
-        try {
-            final Db2Connection conn = testConnection();
-            { // CapParams PruneInterval Block
-                LOGGER.info("Setting PruneInterval to {} seconds", pruneIntervalInSec);
-                conn.prepareUpdate(
-                        "UPDATE " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_PARAMS_TABLE_NAME + "\n" +
-                                "SET PRUNE_INTERVAL = ?",
-                        ps -> {
-                            ps.setInt(1, pruneIntervalInSec);
-                            ps.execute();
-                        });
-                conn.commit();
-            } // CapParams PruneInterval Block
-            { // Get Physical Change Table from Register Block
-                LOGGER.info("Getting Physical Change Table from Register Block");
-                conn.prepareQuery(
-                        "SELECT PHYS_CHANGE_OWNER, PHYS_CHANGE_TABLE \n" +
-                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + "\n" +
-                                "WHERE SOURCE_OWNER = ? \n" +
-                                "AND SOURCE_TABLE = ?",
-                        ps -> {
-                            ps.setString(1, targetTableSchemaName);
-                            ps.setString(2, targetTableName);
-                        },
-                        rs -> {
-                            while (rs.next()) {
-                                physChangeOwner.set(rs.getString("PHYS_CHANGE_OWNER"));
-                                physChangeTable.set(rs.getString("PHYS_CHANGE_TABLE"));
-                            }
-                        });
-                LOGGER.info("PhysChangeOwner: {}, PhysChangeTable: {}", physChangeOwner, physChangeTable);
-                pruneControlAndReinitializeCapMap.put(MAP_KEY_CHANGE_TABLE_OWNER, physChangeOwner.get());
-                pruneControlAndReinitializeCapMap.put(MAP_KEY_CHANGE_TABLE_NAME, physChangeTable.get());
-            } // Get Physical Change Table from Register Block
-            { // Truncate PruneCtl Block
-                LOGGER.info("Truncating PruneCtl Block");
-                conn.execute("TRUNCATE TABLE " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " IMMEDIATE");
-                conn.commit();
-            } // Truncate PruneCtl Block
-            { // PruneCtl Block
-                LOGGER.info("Setting PruneCtl Block");
-
-                conn.prepareUpdate(
-                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " (" +
-                                "TARGET_SERVER, TARGET_OWNER, TARGET_TABLE, SYNCHTIME, SYNCHPOINT, " +
-                                "SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, " +
-                                "CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, " +
-                                "PHYS_CHANGE_TABLE, MAP_ID) " +
-                                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                        ps -> {
-                            ps.setString(1, targetSystem);
-                            ps.setString(2, targetTableSchemaName);
-                            ps.setString(3, targetTableName);
-                            ps.setTimestamp(4, Timestamp.from(Instant.EPOCH));
-                            ps.setBytes(5, LSN_FROM_ZERO_STRING.getBinary());
-                            ps.setString(6, targetTableSchemaName);
-                            ps.setString(7, targetTableName);
-                            ps.setShort(8, Short.parseShort("0"));
-                            ps.setString(9, applyQual);
-                            ps.setString(10, setName);
-                            ps.setString(11, "CTL_SER");
-                            ps.setShort(12, Short.parseShort("8"));
-                            ps.setString(13, "CTLALAS");
-                            ps.setString(14, physChangeOwner.get());
-                            ps.setString(15, physChangeTable.get());
-                            ps.setString(16, mapId);
-                            ps.execute();
-                        });
-                conn.commit();
-            } // PruneCtl Block
-            { // Truncate PruneSet Block
-                LOGGER.info("Truncating PruneSet Block");
-                conn.execute("TRUNCATE TABLE " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " IMMEDIATE");
-                conn.commit();
-            } // Truncate PruneSet Block
-            { // Populate PruneSet Block
-                LOGGER.info("Populating PruneSet Block");
-                conn.prepareUpdate(
-                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + "\n" +
-                                "(TARGET_SERVER, APPLY_QUAL, SET_NAME, SYNCHTIME, SYNCHPOINT)\n" +
-                                "VALUES(?,?,?,?,?)",
-                        ps -> {
-                            ps.setString(1, targetSystem);
-                            ps.setString(2, applyQual);
-                            ps.setString(3, setName);
-                            ps.setTimestamp(4, Timestamp.from(Instant.EPOCH));
-                            ps.setBytes(5, hexStringToByteArray(LSN_ZERO_STRING));
-                            ps.execute();
-                        });
-                conn.commit();
-            } // Populate PruneSet Block
-            { // CapSignal - Restart Cap for MapId Block
-                LOGGER.info("Restarting Cap for MapId Block");
-                conn.prepareUpdate(
-                        "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_SIGNAL_TABLE_NAME + "\n" +
-                                "(SIGNAL_TYPE, SIGNAL_SUBTYPE, SIGNAL_INPUT_IN, SIGNAL_STATE)\n" +
-                                "VALUES ('CMD', 'CAPSTART', ?, 'P')",
-                        ps -> {
-                            ps.setString(1, mapId);
-                            ps.execute();
-                        });
-                conn.commit();
-            } // CapSignal - Restart Cap for MapId Block
-            { // Confirm Prune Data is in Place Block
-                LOGGER.info("Confirming Prune Data is in Place Block");
-                conn.prepareQuery(
-                        "SELECT ips.TARGET_SERVER, ips.synchpoint, ips.SET_NAME, ips.TARGET_SERVER, ips.APPLY_QUAL, " +
-                                "ip.PHYS_CHANGE_OWNER, ip.PHYS_CHANGE_TABLE \n" +
-                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " ips, \n" +
-                                CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " ip \n" +
-                                "WHERE ips.SET_NAME = ip.SET_NAME = ?\n" +
-                                "AND ips.TARGET_SERVER = ip.TARGET_SERVER = ?\n" +
-                                "AND ips.APPLY_QUAL = ip.APPLY_QUAL = ?",
-                        ps -> {
-                            ps.setString(1, setName);
-                            ps.setString(2, targetSystem);
-                            ps.setString(3, applyQual);
-                        },
-                        rs -> {
-                            while (rs.next()) {
-                                LOGGER.info("Prune Data record found. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
-                                        "SynchPoint: {}\nPhysChangeOwner: {}\nPhysChangeTable: {}",
-                                        rs.getString("TARGET_SERVER"),
-                                        rs.getString("APPLY_QUAL"),
-                                        rs.getString("SET_NAME"),
-                                        rs.getString("synchpoint"),
-                                        rs.getString("PHYS_CHANGE_OWNER"),
-                                        rs.getString("PHYS_CHANGE_TABLE"));
-                            }
-                        });
-            } // Confirm Prune Data is in Place Block
-        }
-        catch (SQLException e) {
-            System.err.println("SQL Error: " + e.getSQLState() + " " + e.getMessage());
-            e.printStackTrace();
-        }
-        return pruneControlAndReinitializeCapMap;
-    }
-
     public static Lsn getLsnSyncPointForPruneSet(final String applyQual,
                                                  final String setName,
                                                  final String targetSystem) {
         {
             final Db2Connection conn = testConnection();
-            LOGGER.info("Getting the current LSN on the table.");
-            AtomicReference<String> lsnString = new AtomicReference<>();
+            LOGGER.info("Getting the current LSN for the prune set defined by setName {} " +
+                    "target_server {} apply_qual {}", setName, targetSystem, applyQual);
+            AtomicReference<byte[]> lsnBytes = new AtomicReference<>();
             try {
                 conn.prepareQuery(
-                        "SELECT SYNCHPOINT \n" +
-                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + "\n" +
-                                "WHERE SET_NAME = ?\n" +
-                                "AND TARGET_SERVER = ?\n" +
+                        "SELECT SYNCHPOINT " +
+                                "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " " +
+                                "WHERE SET_NAME = ? " +
+                                "AND TARGET_SERVER = ? " +
                                 "AND APPLY_QUAL = ?",
                         ps -> {
                             ps.setString(1, setName);
@@ -488,16 +340,19 @@ public class TestHelper {
                             ps.setString(3, applyQual);
                         },
                         rs -> {
+                            int numRowsFound = 0;
                             while (rs.next()) {
-                                lsnString.set(rs.getString("SYNCHPOINT"));
-
+                                numRowsFound++;
+                                LOGGER.info("Found {} rows in the prune set table", numRowsFound);
+                                lsnBytes.set(rs.getBytes("SYNCHPOINT"));
                             }
+                            LOGGER.info("Done reporting the contents of Prune set with {} rows.", numRowsFound);
                         });
             }
             catch (SQLException e) {
                 throw new RuntimeException(e);
             }
-            return Lsn.valueOf(lsnString.get());
+            return Lsn.valueOf(lsnBytes.get());
         }
     }
 
@@ -506,34 +361,431 @@ public class TestHelper {
                                                      final String changeTableName) {
 
         final Db2Connection conn = testConnection();
-        LOGGER.info("Getting the last change LSN for {}.{}", changeTableOwner, changeTableName);
-        AtomicReference<String> lsnString = new AtomicReference<>();
+        LOGGER.info("Getting the last change LSN for change table {}.{}", changeTableOwner, changeTableName);
+        AtomicReference<byte[]> lsnBytes = new AtomicReference<>();
         try {
             conn.prepareQuery(
-                    "SELECT IBMSNAP_COMMITSEQ \n" +
-                            "FROM " + changeTableOwner + "." + changeTableName + "\n" +
+                    "SELECT IBMSNAP_COMMITSEQ " +
+                            "FROM " + changeTableOwner + "." + changeTableName + " " +
                             "ORDER BY IBMSNAP_COMMITSEQ DESC LIMIT 1",
                     ps -> {
                     },
                     rs -> {
                         while (rs.next()) {
-                            lsnString.set(rs.getString("IBMSNAP_COMMITSEQ"));
+                            lsnBytes.set(rs.getBytes("IBMSNAP_COMMITSEQ"));
                         }
                     });
         }
         catch (SQLException e) {
             throw new RuntimeException(e);
         }
-        return Lsn.valueOf(lsnString.get());
+        return Lsn.valueOf(lsnBytes.get());
     }
 
-    // Helper method to convert hex string to byte array
-    public static byte[] hexStringToByteArray(String s) {
-        int len = s.length();
-        byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+    public static int getSizeOfChangeTable(
+                                           final String changeTableOwner,
+                                           final String changeTableName) {
+
+        final AtomicReference<Integer> size = new AtomicReference<>();
+        final Db2Connection conn = testConnection();
+        LOGGER.info("Getting size of change table {}.{}", changeTableOwner, changeTableName);
+        try {
+            conn.prepareQuery(
+                    "SELECT COUNT(*) " +
+                            "FROM " + changeTableOwner + "." + changeTableName + " ",
+                    ps -> {
+                    },
+                    rs -> {
+                        if (rs.next()) {
+                            size.set(rs.getInt(1));
+                        }
+                        else {
+                            size.set(0);
+                        }
+                        LOGGER.info("Size of table {} is {}", changeTableOwner + "." + changeTableName, size.get());
+                    });
         }
-        return data;
+        catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+        return size.get();
+    }
+
+    public static void getChangeTablesForPhysicalTableFromRegistrationTable(
+                                                                            final String sourceSchemaName, final String sourceTableName,
+                                                                            final Map<String, String> pruneControlAndCapMap) {
+        final AtomicReference<String> physChangeOwner = new AtomicReference<>();
+        final AtomicReference<String> physChangeTable = new AtomicReference<>();
+        final JdbcConnection conn = testConnection();
+        LOGGER.info("Getting Physical Change Table from Registration Table");
+        try {
+            conn.prepareQuery(
+                    "SELECT PHYS_CHANGE_OWNER, PHYS_CHANGE_TABLE \n" +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + "\n" +
+                            "WHERE SOURCE_OWNER = ? \n" +
+                            "AND SOURCE_TABLE = ?",
+                    ps -> {
+                        ps.setString(1, sourceSchemaName);
+                        ps.setString(2, sourceTableName);
+                    },
+                    rs -> {
+                        while (rs.next()) {
+                            physChangeOwner.set(rs.getString("PHYS_CHANGE_OWNER"));
+                            physChangeTable.set(rs.getString("PHYS_CHANGE_TABLE"));
+                        }
+                    });
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        LOGGER.info("PhysChangeOwner: {}, PhysChangeTable: {}", physChangeOwner, physChangeTable);
+        pruneControlAndCapMap.put(MAP_KEY_CHANGE_TABLE_OWNER, physChangeOwner.get());
+        pruneControlAndCapMap.put(MAP_KEY_CHANGE_TABLE_NAME, physChangeTable.get());
+    }
+
+    public static void checkAndCorrectPhysicalChangeTablesBetweenRegistrationAndPrunectlForTable(
+                                                                                                 final String sourceSchemaName,
+                                                                                                 final String sourceTableName,
+                                                                                                 final Map<String, String> pruneControlAndCapMap) {
+        final JdbcConnection conn = testConnection();
+        LOGGER.info("Updating the prunectl table to use the correct change table names as found on the registration tables");
+        if (!pruneControlAndCapMap.containsKey(MAP_KEY_CHANGE_TABLE_OWNER) || !pruneControlAndCapMap.containsKey(MAP_KEY_CHANGE_TABLE_NAME)) {
+            getChangeTablesForPhysicalTableFromRegistrationTable(sourceSchemaName, sourceTableName, pruneControlAndCapMap);
+        }
+        final String physChangeOwner = pruneControlAndCapMap.get(MAP_KEY_CHANGE_TABLE_OWNER);
+        final String physChangeTable = pruneControlAndCapMap.get(MAP_KEY_CHANGE_TABLE_NAME);
+        try {
+            conn.prepareUpdate(
+                    "UPDATE " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " " +
+                            "SET PHYS_CHANGE_OWNER = ?, PHYS_CHANGE_TABLE = ? " +
+                            "WHERE SOURCE_OWNER = ? " +
+                            "AND SOURCE_TABLE = ?",
+                    ps -> {
+                        ps.setString(1, physChangeOwner);
+                        ps.setString(2, physChangeTable);
+                        ps.setString(3, sourceSchemaName);
+                        ps.setString(4, sourceTableName);
+                    });
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void getPruneSetRecordForPruneSet(final String targetServer, final String applyQual, final String setName) {
+        try {
+            JdbcConnection conn = testConnection();
+            LOGGER.info("Confirming Prune Set Data is in Place");
+            final AtomicReference<Integer> numRecordsInSetTable = new AtomicReference<>();
+            final AtomicReference<Integer> numRecordsInSetTableForSpecificSet = new AtomicReference<>();
+            conn.prepareQuery(
+                    "SELECT ips.TARGET_SERVER, ips.SYNCHPOINT, ips.SET_NAME, ips.APPLY_QUAL " +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " ips ",
+                    s -> {
+                    },
+                    rs -> {
+                        int rowsFound = 0;
+                        while (rs.next()) {
+                            rowsFound++;
+                            LOGGER.info("Prune Set record found. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
+                                    "SynchPoint: {}",
+                                    rs.getString("TARGET_SERVER"),
+                                    rs.getString("APPLY_QUAL"),
+                                    rs.getString("SET_NAME"),
+                                    rs.getBytes("SYNCHPOINT"));
+                        }
+                        LOGGER.info("Done reporting the the contents of Prune set with {} rows.", rowsFound);
+                        numRecordsInSetTable.set(rowsFound);
+                    });
+            LOGGER.info("Confirming Prune Set Data is in Place");
+            conn.prepareQuery(
+                    "SELECT ips.TARGET_SERVER, ips.SYNCHPOINT, ips.SET_NAME, ips.APPLY_QUAL " +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " ips " +
+                            "WHERE APPLY_QUAL = ? " +
+                            "AND SET_NAME = ?",
+                    s -> {
+                        s.setString(1, applyQual);
+                        s.setString(2, setName);
+                    },
+                    rs -> {
+                        int rowsFound = 0;
+                        while (rs.next()) {
+                            rowsFound++;
+                            LOGGER.info("Prune Set record found for specific match. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
+                                    "SynchPoint: {}",
+                                    rs.getString("TARGET_SERVER"),
+                                    rs.getString("APPLY_QUAL"),
+                                    rs.getString("SET_NAME"),
+                                    rs.getBytes("SYNCHPOINT"));
+                        }
+                        LOGGER.info("Done reporting the the contents of Prune set with {} rows.", rowsFound);
+                        numRecordsInSetTableForSpecificSet.set(rowsFound);
+                    });
+            LOGGER.info("Rows on prune set table: {}", numRecordsInSetTable.get());
+            LOGGER.info("Rows on prune set matching prune set information: {}", numRecordsInSetTableForSpecificSet.get());
+            if (numRecordsInSetTableForSpecificSet.get() == 0) {
+                throw new IllegalStateException("No matching rows found on the pruneSet table for the provided information.");
+            }
+            if (numRecordsInSetTableForSpecificSet.get() > 1) {
+                throw new IllegalStateException("More than one target system found ");
+            }
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void insertRecordToPruneSetTable(final String targetServer, final String applyQual, final String setName) {
+        JdbcConnection conn = testConnection();
+        LOGGER.info("Inserting record to Prune Set Table");
+        try {
+            conn.prepareUpdate(
+                    "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_SET_TABLE_NAME + " " +
+                            "(TARGET_SERVER, APPLY_QUAL, SET_NAME, SYNCHTIME, SYNCHPOINT) " +
+                            "VALUES (?, ?, ?, ?, ?)",
+                    ps -> {
+                        ps.setString(1, targetServer);
+                        ps.setString(2, applyQual);
+                        ps.setString(3, setName);
+                        ps.setTimestamp(4, Timestamp.from(Instant.EPOCH));
+                        ps.setBytes(5, LSN_FROM_ZERO_STRING.getBinary());
+                    });
+            conn.commit();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void setOldSynchpointOnRegistrationTable(final String sourceSchemaName, final String sourceTableName) {
+        LOGGER.info("Setting Old Synchpoint on Registration Table");
+        JdbcConnection conn = testConnection();
+        try {
+            conn.prepareUpdate(
+                    "UPDATE " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + " " +
+                            "SET CD_OLD_SYNCHPOINT = ? " +
+                            "WHERE SOURCE_OWNER = ? AND SOURCE_TABLE = ?",
+                    ps -> {
+                        ps.setBytes(1, LSN_FROM_ZERO_STRING.getBinary());
+                        ps.setString(2, sourceSchemaName);
+                        ps.setString(3, sourceTableName);
+
+                    });
+            conn.commit();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Lsn getOldSynchpointOnRegistrationTable(final String sourceSchemaName, final String sourceTableName) {
+        LOGGER.info("Getting Old Synchpoint on Registration Table");
+        final AtomicReference<byte[]> snapshotBytes = new AtomicReference<>();
+        JdbcConnection conn = testConnection();
+        try {
+            conn.prepareQuery(
+                    "SELECT CD_OLD_SYNCHPOINT " +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + REGISTER_CTL_TABLE_NAME + " " +
+                            "WHERE SOURCE_OWNER = ? AND SOURCE_TABLE = ?",
+                    ps -> {
+                        ps.setString(1, sourceSchemaName);
+                        ps.setString(2, sourceTableName);
+                    },
+                    rs -> {
+                        while (rs.next()) {
+                            snapshotBytes.set(rs.getBytes("CD_OLD_SYNCHPOINT"));
+                        }
+                    });
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Lsn.valueOf(snapshotBytes.get());
+    }
+
+    public static void createDBRecords(final int numToInsert) throws SQLException {
+
+        JdbcConnection connection = testConnection();
+        for (int j = 0; j < numToInsert; j++) {
+            LOGGER.info("Inserting record with id {}", currentIdForTestEvents);
+            connection.execute(
+                    "INSERT INTO tablea VALUES(" + currentIdForTestEvents + ", 'b')");
+            LOGGER.info("Inserted record with id {}", currentIdForTestEvents);
+            connection.commit();
+            currentIdForTestEvents++;
+        }
+    }
+
+    public static void readCapTrace(int numToRead) throws SQLException {
+        JdbcConnection conn = testConnection();
+        LOGGER.info("Reading capture trace table to see activity.");
+        conn.prepareQuery(
+                "SELECT OPERATION, TRACE_TIME, DESCRIPTION " +
+                        "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CAP_TRACE_TABLE_NAME + " " +
+                        "ORDER BY TRACE_TIME DESC LIMIT ?",
+                s -> {
+                    s.setInt(1, numToRead);
+                },
+                rs -> {
+                    int rowsFound = 0;
+                    while (rs.next()) {
+                        rowsFound++;
+                        LOGGER.info("Cap Trace: Operation: {} TRACE_TIME: {}, DESCRIPTION: {}",
+                                rs.getString("OPERATION"),
+                                rs.getString("TRACE_TIME"),
+                                rs.getString("DESCRIPTION"));
+                    }
+                    LOGGER.info("Done reporting the the contents of Prune set with {} rows.", rowsFound);
+                });
+    }
+
+    public static String getPruneCtlRecordsForTable(final String sourceTableSchemaName, final String sourceTableName,
+                                                    final String targetServer, final String applyQual, final String setName,
+                                                    final Map<String, String> pruneControlAndCapMap) {
+        JdbcConnection conn = testConnection();
+        LOGGER.info("Getting PruneCtl Information");
+        final AtomicReference<String> mapId = new AtomicReference<>();
+
+        try {
+            conn.prepareQuery(
+                    "SELECT TARGET_SERVER, TARGET_OWNER, TARGET_TABLE, SYNCHTIME, SYNCHPOINT, " +
+                            "SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, " +
+                            "CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, " +
+                            "PHYS_CHANGE_TABLE, MAP_ID " +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " " +
+                            "WHERE SOURCE_OWNER = ? " +
+                            "AND SOURCE_TABLE = ? ",
+                    ps -> {
+                        ps.setString(1, sourceTableSchemaName);
+                        ps.setString(2, sourceTableName);
+                    },
+                    rs -> {
+                        while (rs.next()) {
+                            LOGGER.info("Prune Data record found on non-specific query on prunectl. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
+                                    "SynchPoint: {}\nPhysChangeOwner: {}\nPhysChangeTable: {}",
+                                    rs.getString("TARGET_SERVER"),
+                                    rs.getString("APPLY_QUAL"),
+                                    rs.getString("SET_NAME"),
+                                    rs.getString("SYNCHPOINT"),
+                                    rs.getString("PHYS_CHANGE_OWNER"),
+                                    rs.getString("PHYS_CHANGE_TABLE"));
+                        }
+                        LOGGER.info("Done reporting the the contents of Prune ctl without prune set filters.");
+                    });
+            conn.prepareQuery(
+                    "SELECT TARGET_SERVER, TARGET_OWNER, TARGET_TABLE, SYNCHTIME, SYNCHPOINT, " +
+                            "SOURCE_OWNER, SOURCE_TABLE, SOURCE_VIEW_QUAL, APPLY_QUAL, SET_NAME, " +
+                            "CNTL_SERVER, TARGET_STRUCTURE, CNTL_ALIAS, PHYS_CHANGE_OWNER, " +
+                            "PHYS_CHANGE_TABLE, MAP_ID " +
+                            "FROM " + CONTROL_TABLE_SCHEMA_NAME + "." + PRUNE_CTL_TABLE_NAME + " " +
+                            "WHERE SOURCE_OWNER = ? " +
+                            "AND SOURCE_TABLE = ? " +
+                            "AND APPLY_QUAL = ? " +
+                            "AND SET_NAME = ? " +
+                            "AND TARGET_SERVER = ? " +
+                            "LIMIT 1",
+                    ps -> {
+                        ps.setString(1, sourceTableSchemaName);
+                        ps.setString(2, sourceTableName);
+                        ps.setString(3, applyQual);
+                        ps.setString(4, setName);
+                        ps.setString(5, targetServer);
+                    },
+                    rs -> {
+                        int numFoundForSpecificQuery = 0;
+                        while (rs.next()) {
+                            numFoundForSpecificQuery++;
+                            LOGGER.info("Prune Data record found on Prunectl. \nTargetServer: {}\nApplyQual: {}\nSetName: {}\n" +
+                                    "SynchPoint: {}\nPhysChangeOwner: {}\nPhysChangeTable: {}",
+                                    rs.getString("TARGET_SERVER"),
+                                    rs.getString("APPLY_QUAL"),
+                                    rs.getString("SET_NAME"),
+                                    rs.getString("SYNCHPOINT"),
+                                    rs.getString("PHYS_CHANGE_OWNER"),
+                                    rs.getString("PHYS_CHANGE_TABLE"));
+                            mapId.set(rs.getString("MAP_ID"));
+                        }
+                        LOGGER.info("Done reporting the the contents of Prune ctl with {} records found.", numFoundForSpecificQuery);
+                        if (numFoundForSpecificQuery == 0) {
+                            LOGGER.error("No records for table {}.{}, using applyQual {}, targetServer {} setName {}",
+                                    sourceTableSchemaName, sourceTableName, applyQual, targetServer, setName);
+                            throw new IllegalStateException("The database does not currently have matching records for prune " +
+                                    "on both the registration and pruneCtl tables for the expected configuration.");
+                        }
+                    });
+            pruneControlAndCapMap.put(MAP_KEY_PRUNECTL_MAP_ID, mapId.get());
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return mapId.get();
+    }
+
+    public static void signalCapRestartForMapId(final String mapId) {
+        JdbcConnection conn = testConnection();
+        LOGGER.info("Restarting Cap for MapId: {}");
+        try {
+            conn.prepareUpdate(
+                    "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_SIGNAL_TABLE_NAME + "\n" +
+                            "(SIGNAL_TYPE, SIGNAL_SUBTYPE, SIGNAL_INPUT_IN, SIGNAL_STATE)\n" +
+                            "VALUES ('CMD', 'CAPSTART', ?, 'P')",
+                    ps -> {
+                        ps.setString(1, mapId);
+
+                    });
+            conn.commit();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        LOGGER.info("Sent signal record for restarting Cap for MapId: {}", mapId);
+    }
+
+    public static void setCapParamsPruneInterval(int pruneIntervalInSec) {
+        {
+            final Db2Connection conn = testConnection();
+            LOGGER.info("Setting PruneInterval to {} seconds", pruneIntervalInSec);
+            try {
+                conn.prepareUpdate(
+                        "UPDATE " + CONTROL_TABLE_SCHEMA_NAME + "." + CAP_PARAMS_TABLE_NAME + " " +
+                                "SET PRUNE_INTERVAL = ?",
+                        ps -> {
+                            ps.setInt(1, pruneIntervalInSec);
+                        });
+                conn.commit();
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /*
+     * Table must be on the registration table, with a non-null CD_OLD_SYNCHPOINT.
+     * It must then be on the prunectl tale, where the ts, aq, and sn will be checked, and a mapId will be checked
+     * It must then be on the pruneSet table, where the ts, aq, and sn will be checked, and a synctime be identified.
+     * The pruneSet table will then be checked for anything with the same setName and applyQual but a different targetServer.
+     */
+    public static void validatePruneReadinessForTable(final String sourceTableSchema, final String sourceTableName,
+                                                      final String targetServer, final String applyQual, final String setName) {
+        final Map<String, String> validationMap = new HashMap<String, String>();
+        LOGGER.info("___________________" + " Prune Setup Validation " + "___________________");
+        getChangeTablesForPhysicalTableFromRegistrationTable(sourceTableSchema, sourceTableName, validationMap);
+        final Lsn currentRegisteredCdOldSynchpoint = TestHelper.getOldSynchpointOnRegistrationTable(sourceTableSchema, sourceTableName);
+        if (currentRegisteredCdOldSynchpoint.equals(Lsn.NULL) || currentRegisteredCdOldSynchpoint == null) {
+            LOGGER.error("The LSN on the registration table for {}.{} is null.  " +
+                    "This will mark it inactive and it won't be pruned", sourceTableSchema, sourceTableName);
+            throw new IllegalStateException("The LSN on the registration table for {}.{} is null. This will mark it inactive and it won't be pruned");
+        }
+        final String changeSchemaName = validationMap.get(MAP_KEY_CHANGE_TABLE_OWNER);
+        final String changeTableName = validationMap.get(MAP_KEY_CHANGE_TABLE_NAME);
+        LOGGER.info("Change Table Name: {}.{}", changeSchemaName, changeTableName);
+
+        getPruneCtlRecordsForTable(sourceTableSchema, sourceTableName, targetServer, applyQual, setName, validationMap);
+        final String mapId = validationMap.get(MAP_KEY_PRUNECTL_MAP_ID);
+        LOGGER.info("Prunectl MapId for this prune set: {}", mapId);
+
+        getPruneSetRecordForPruneSet(targetServer, applyQual, setName);
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1843
Changes to allow the connector to update the prune table such that it can operate without the apply agent of DB2 while not overfilling the change tables.  Significant test work to make sure the database is in the right configuration to allow the prune thread to work (finding that a table name is double quoted in the purgectl table).   Matching updates to core debezium with documentation to follow.