### PR TITLE
debezium/dbz#453 Derive field group order implicitly from ConfigDefinition ordering

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -401,6 +401,9 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             .withDisplayName("z/OS ignore stop LSN")
             .withDefault(false)
             .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
             .withDescription("If true, causes the connector to ignore the stop LSN value from the " +
                     "IBMSNAP_REGISTER.CD_OLD_SYNCHPOINT column when polling. " +
                     "Apply this if events are getting dropped due to the stop LSN being " +
@@ -412,7 +415,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
             .withDisplayName("Snapshot mode")
             .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 0))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDescription("The criteria for running a snapshot upon startup of the connector. "
@@ -423,7 +426,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     public static final Field SNAPSHOT_ISOLATION_MODE = Field.create("snapshot.isolation.mode")
             .withDisplayName("Snapshot isolation mode")
             .withEnum(SnapshotIsolationMode.class, SnapshotIsolationMode.REPEATABLE_READ)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 1))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDescription("Controls which transaction isolation level is used and how long the connector locks the monitored tables. "
@@ -441,7 +444,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.EXCLUSIVE)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 2))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withDescription(
                     "Controls how the connector holds locks on tables while performing the schema snapshot when `snapshot.isolation.mode` is `REPEATABLE_READ` or `EXCLUSIVE`. The 'exclusive' "
                             + "which means the connector will hold a table lock for exclusive table access for just the initial portion of the snapshot "
@@ -453,7 +456,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     public static final Field CDC_CONTROL_SCHEMA = Field.create("cdc.control.schema")
             .withDisplayName("CDC control schema")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 0))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_CDC_SCHEMA)
@@ -463,7 +466,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     public static final Field CDC_CHANGE_TABLES_SCHEMA = Field.create("cdc.change.tables.schema")
             .withDisplayName("CDC change tables schema")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 1))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_CDC_SCHEMA)
@@ -473,7 +476,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
     public static final Field DB2_PLATFORM = Field.create("db2.platform")
             .withDisplayName("Db2 platform")
             .withEnum(Db2Platform.class, Db2Platform.LUW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 2))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDescription("Informs connector which Db2 implementation platform it is connected to. "
@@ -492,6 +495,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     "The maximum number of seconds for a streaming query to include that query's result set, starting from the earliest row in this query.  " +
                             "Used to limit the size of queries when the change table is large to avoid excessive resource usage. If 0, no timespan limit will apply.")
             .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withImportance(Importance.LOW)
             .withWidth(Width.SHORT)
             .withDefault(DEFAULT_STREAMING_QUERY_TIMESPAN_SECONDS)
@@ -516,6 +520,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                             " default false.")
             .withType(Type.BOOLEAN)
             .withImportance(Importance.MEDIUM)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.SHORT)
             .withDefault(false);
 
@@ -525,6 +530,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                             "when updating the table for this instance.")
             .withType(Type.STRING)
             .withImportance(Importance.MEDIUM)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withValidation((config, field, problems) -> {
                 String value = config.getString(field);
@@ -541,12 +547,14 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                 }
                 return 0;
             });
+
     public static final Field UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL = Field.create("update.capture.table.prune.min.interval.ms")
             .withDescription(
                     "The minimum number of milliseconds between the connector instance's update of the prune point for " +
                             "the subscription set.  Default is 10000 (10 seconds).")
             .withType(Type.INT)
             .withImportance(Importance.LOW)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.SHORT)
             .withDefault(10000);
 
@@ -556,6 +564,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                             "to avoid the risk of an unnecessary snapshot due to the last processed lsn not being present in the change table.")
             .withType(Type.BOOLEAN)
             .withImportance(Importance.LOW)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withDefault(true);
 
@@ -564,6 +573,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     "The apply_qual name that represents the apply agent (this instance) to the subscription set.")
             .withType(Type.STRING)
             .withImportance(Importance.LOW)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM);
 
     public static final Field UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER = Field.create("update.capture.table.prune.target.server")
@@ -571,6 +581,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     "The target_server name that represents the apply agent's target (where the data is going) for the subscription set.")
             .withType(Type.STRING)
             .withImportance(Importance.LOW)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM);
 
     public static final Field UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME = Field.create("update.capture.table.prune.procedure.override.name")
@@ -578,6 +589,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     "The name of a prepared statement in the database that will be used instead of direct sql to allow for DBA control of the update code where needed.")
             .withType(Type.STRING)
             .withImportance(Importance.LOW)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.LONG);
 
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
@@ -585,39 +597,26 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("Db2")
-            .excluding(CommonConnectorConfig.QUERY_FETCH_SIZE,
-                    CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER)
-            .type(
-                    HOSTNAME,
-                    PORT,
-                    USER,
-                    PASSWORD,
-                    DATABASE_NAME)
-            .connector(
-                    SNAPSHOT_MODE,
-                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
-                    SCHEMA_NAME_ADJUSTMENT_MODE,
-                    QUERY_FETCH_SIZE,
-                    CDC_CONTROL_SCHEMA,
-                    CDC_CHANGE_TABLES_SCHEMA,
-                    DB2_PLATFORM,
-                    UPDATE_CAPTURE_TABLE_PRUNE_IND,
-                    UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME,
-                    UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL,
-                    UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT,
-                    UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL,
-                    UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER,
-                    UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME)
-            .events(SOURCE_INFO_STRUCT_MAKER)
             .excluding(
+                    CommonConnectorConfig.QUERY_FETCH_SIZE,
+                    CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER,
                     SCHEMA_INCLUDE_LIST,
                     SCHEMA_EXCLUDE_LIST,
-                    // additional fields
                     BINARY_HANDLING_MODE,
                     INCLUDE_SCHEMA_COMMENTS,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES,
                     SNAPSHOT_MAX_THREADS,
                     DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY)
+            .group(Field.Group.CONNECTION, HOSTNAME, PORT, USER, PASSWORD, DATABASE_NAME)
+            .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_ISOLATION_MODE, SNAPSHOT_LOCKING_MODE)
+            .group(Field.Group.CONNECTOR, INCREMENTAL_SNAPSHOT_CHUNK_SIZE, SCHEMA_NAME_ADJUSTMENT_MODE,
+                    QUERY_FETCH_SIZE, SOURCE_INFO_STRUCT_MAKER)
+            .group(Field.Group.CONNECTOR_ADVANCED, CDC_CONTROL_SCHEMA, CDC_CHANGE_TABLES_SCHEMA, DB2_PLATFORM,
+                    Z_STOP_LSN_IGNORE, STREAMING_QUERY_TIMESPAN_SECONDS,
+                    UPDATE_CAPTURE_TABLE_PRUNE_IND, UPDATE_CAPTURE_TABLE_PRUNE_SET_NAME,
+                    UPDATE_CAPTURE_TABLE_PRUNE_MIN_INTERVAL, UPDATE_CAPTURE_TABLE_PRUNE_LSN_DECREMENT,
+                    UPDATE_CAPTURE_TABLE_PRUNE_APPLY_QUAL, UPDATE_CAPTURE_TABLE_PRUNE_TARGET_SERVER,
+                    UPDATE_CAPTURE_TABLE_PRUNE_PROCEDURE_OVERRIDE_NAME)
             .create();
 
     protected static ConfigDef configDef() {


### PR DESCRIPTION
This PR applies the changes from debezium/debezium#7286 to the Db2 connector.

## Changes
- Removed explicit position numbers from all `createGroupEntry(Field.Group.XXX, N)` calls, replacing them with `createGroupEntry(Field.Group.XXX)`
- Replaced the old `CONFIG_DEFINITION` API with the new `.group()` API in `Db2ConnectorConfig`
- Added missing `.withGroup()` to fields that had no group assignment

## Details
Following the pattern established in debezium/debezium#7286, this change removes manual position numbers from field group entries and derives group order implicitly from the order fields appear in the ConfigDefinition. This eliminates the need to maintain explicit position numbers and reduces the risk of ordering conflicts.

The schema generator now uses the new [buildFieldGroupOrderMap()](cci:1://file:///Users/binayakdas/Desktop/debezium%20main/debezium/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/schema/debezium/DebeziumDescriptorSchemaCreator.java:81:4-94:5) method to assign sequential positions per Field.Group based on the list order, matching the implicit pattern used in `Field#group()`.

Fixes dbz#453