### PR TITLE
debezium/dbz#2162 Map LSN to transaction commit timestamp using IBMSNAP_UOW

### DIFF
--- a/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -60,7 +60,7 @@ public class Db2Connection extends JdbcConnection {
 
     private static final String LOCK_TABLE = "SELECT * FROM # WITH CS"; // DB2
 
-    private static final String LSN_TO_TIMESTAMP = "SELECT CURRENT TIMEstamp FROM sysibm.sysdummy1  WHERE ? > X'00000000000000000000000000000000'";
+    private static final String LSN_TO_TIMESTAMP_QUERY = "SELECT IBMSNAP_LOGMARKER FROM %s.IBMSNAP_UOW WHERE IBMSNAP_COMMITSEQ = ?";
 
     private static final String GET_LIST_OF_KEY_COLUMNS = "SELECT "
             + "CAST((t.TBSPACEID * 65536 +  t.TABLEID )AS INTEGER ) as objectid, "
@@ -86,6 +86,7 @@ public class Db2Connection extends JdbcConnection {
     private final String realDatabaseName;
 
     private final BoundedConcurrentHashMap<Lsn, Instant> lsnToInstantCache;
+    private final String lsnToTimestampQuery;
 
     private final Db2ConnectorConfig connectorConfig;
     private final Db2PlatformAdapter platform;
@@ -102,6 +103,7 @@ public class Db2Connection extends JdbcConnection {
 
         connectorConfig = config;
         lsnToInstantCache = new BoundedConcurrentHashMap<>(100);
+        lsnToTimestampQuery = String.format(LSN_TO_TIMESTAMP_QUERY, connectorConfig.getCdcControlSchema());
         realDatabaseName = retrieveRealDatabaseName();
         platform = connectorConfig.getDb2Platform().createAdapter(connectorConfig);
     }
@@ -240,8 +242,6 @@ public class Db2Connection extends JdbcConnection {
      * @throws SQLException
      */
     public Instant timestampOfLsn(Lsn lsn) throws SQLException {
-        final String query = LSN_TO_TIMESTAMP;
-
         if (lsn.getBinary() == null) {
             return null;
         }
@@ -251,17 +251,31 @@ public class Db2Connection extends JdbcConnection {
             return cachedInstant;
         }
 
-        return prepareQueryAndMap(query, statement -> {
-            statement.setBytes(1, lsn.getBinary());
-        }, singleResultMapper(rs -> {
-            final Timestamp ts = rs.getTimestamp(1);
-            final Instant ret = (ts == null) ? null : ts.toInstant();
-            LOGGER.trace("Timestamp of lsn {} is {}", lsn, ret);
-            if (ret != null) {
-                lsnToInstantCache.put(lsn, ret);
-            }
-            return ret;
-        }, "LSN to timestamp query must return exactly one value"));
+        Instant ret = null;
+        try {
+            ret = prepareQueryAndMap(lsnToTimestampQuery, statement -> {
+                statement.setBytes(1, lsn.getBinary());
+            }, rs -> {
+                if (rs.next()) {
+                    final Timestamp ts = rs.getTimestamp(1);
+                    return (ts == null) ? null : ts.toInstant();
+                }
+                return null;
+            });
+        }
+        catch (SQLException e) {
+            LOGGER.debug("Failed to retrieve timestamp for LSN {} from IBMSNAP_UOW, falling back to database current timestamp", lsn, e);
+        }
+
+        if (ret == null) {
+            ret = getCurrentTimestamp().orElse(null);
+        }
+
+        LOGGER.trace("Timestamp of lsn {} is {}", lsn, ret);
+        if (ret != null) {
+            lsnToInstantCache.put(lsn, ret);
+        }
+        return ret;
     }
 
     @Override

--- a/src/test/java/io/debezium/connector/db2/Db2ConnectionIT.java
+++ b/src/test/java/io/debezium/connector/db2/Db2ConnectionIT.java
@@ -6,6 +6,10 @@
 
 package io.debezium.connector.db2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.db2.util.TestHelper;
@@ -25,4 +29,50 @@ public class Db2ConnectionIT {
         }
     }
 
+    @Test
+    public void shouldReturnCommitTimestampFromUow() throws Exception {
+        try (Db2Connection connection = TestHelper.adminConnection()) {
+            connection.connect();
+
+            Lsn lsn = Lsn.valueOf("00000000000000000000000000000123");
+            Instant expected = Instant.parse("2026-01-15T10:00:00Z");
+
+            try {
+                // seed IBMSNAP_UOW with lsn -> expected
+                TestHelper.insertUowRow(connection, lsn, expected);
+
+                Instant actual = connection.timestampOfLsn(lsn);
+                assertThat(actual).isEqualTo(expected);
+            }
+            finally {
+                TestHelper.deleteUowRow(connection, lsn);
+            }
+        }
+    }
+
+    @Test
+    public void shouldFallBackToCurrentTimestampWhenUowRowMissing() throws Exception {
+        try (Db2Connection connection = TestHelper.adminConnection()) {
+            connection.connect();
+
+            Lsn lsn = Lsn.valueOf("00000000000000000000000000000099"); // no UOW row exists
+
+            // Ensure no stray row exists from a prior failed run
+            TestHelper.deleteUowRow(connection, lsn);
+
+            Instant before = connection.getCurrentTimestamp().orElseThrow().minusSeconds(10);
+            Instant actual = connection.timestampOfLsn(lsn);
+            Instant after = connection.getCurrentTimestamp().orElseThrow().plusSeconds(10);
+
+            assertThat(actual).isBetween(before, after);
+        }
+    }
+
+    @Test
+    public void shouldReturnNullForNullLsn() throws Exception {
+        try (Db2Connection connection = TestHelper.adminConnection()) {
+            connection.connect();
+            assertThat(connection.timestampOfLsn(Lsn.NULL)).isNull();
+        }
+    }
 }

--- a/src/test/java/io/debezium/connector/db2/util/TestHelper.java
+++ b/src/test/java/io/debezium/connector/db2/util/TestHelper.java
@@ -788,4 +788,28 @@ public class TestHelper {
         getPruneSetRecordForPruneSet(targetServer, applyQual, setName);
 
     }
+
+    public static void insertUowRow(Db2Connection connection, Lsn lsn, Instant timestamp) throws SQLException {
+        final String query = "INSERT INTO " + CONTROL_TABLE_SCHEMA_NAME + ".IBMSNAP_UOW " +
+                "(IBMSNAP_UOWID, IBMSNAP_COMMITSEQ, IBMSNAP_LOGMARKER, IBMSNAP_AUTHTKN, IBMSNAP_AUTHID) " +
+                "VALUES (?, ?, ?, ?, ?)";
+        byte[] uowId = new byte[10];
+        System.arraycopy(lsn.getBinary(), 0, uowId, 0, 10);
+        connection.prepareUpdate(query, ps -> {
+            ps.setBytes(1, uowId); // unique UOWID derived from LSN
+            ps.setBytes(2, lsn.getBinary()); // COMMITSEQ
+            ps.setTimestamp(3, Timestamp.from(timestamp)); // LOGMARKER
+            ps.setString(4, "dummy_authtkn"); // AUTHTKN
+            ps.setString(5, "dummy_authid"); // AUTHID
+        });
+        connection.commit();
+    }
+
+    public static void deleteUowRow(Db2Connection connection, Lsn lsn) throws SQLException {
+        final String query = "DELETE FROM " + CONTROL_TABLE_SCHEMA_NAME + ".IBMSNAP_UOW WHERE IBMSNAP_COMMITSEQ = ?";
+        connection.prepareUpdate(query, ps -> {
+            ps.setBytes(1, lsn.getBinary());
+        });
+        connection.commit();
+    }
 }


### PR DESCRIPTION
Fixes [#2162](https://github.com/debezium/dbz/issues/2162)

### Description
Currently, the DB2 connector maps a Log Sequence Number (LSN) to a timestamp by executing the mock query `SELECT CURRENT TIMEstamp FROM sysibm.sysdummy1 WHERE ? > X'00000000000000000000000000000000'`.

This leads to two distinct issues:
1. **LUW Mode:** It returns the database's current system time at the moment the query is executed, rather than the actual transaction commit time associated with the LSN.
2. **z/OS Mode:** Comparing binary query parameters directly using `>` against a hex literal results in a SQL execution error.

### Solution
This PR resolves both issues by introducing a mapping check against the Unit of Work table (`IBMSNAP_UOW`):
1. **Query actual commit timestamp:** The query is updated to check the `IBMSNAP_UOW` table to map `IBMSNAP_COMMITSEQ` (the LSN) to its corresponding transaction commit time `IBMSNAP_LOGMARKER`.
2. **Fallback logic:** Falls back to querying the database's current timestamp (`getCurrentTimestamp()`) when the UOW lookup returns no matching row (e.g., when the `INSERT_UOW` configuration is set to `OFF` or early pruning occurs), or when the query itself throws a `SQLException`. This preserves the original behavior and keeps the mapping best-effort.
3. **z/OS Compatibility:** Uses parameter equality mapping (`WHERE IBMSNAP_COMMITSEQ = ?`) instead of inequality comparison, preventing SQL execution errors on z/OS.

### Verification
* Added `insertUowRow`/`deleteUowRow` helper methods in `TestHelper.java` to support programmatic seeding and cleanup of the `IBMSNAP_UOW` table, keeping tests idempotent across reruns.
* Added three isolated branch integration tests in `Db2ConnectionIT.java`:
  * `shouldReturnCommitTimestampFromUow`: Asserts the exact resolved timestamp matches the seeded value.
  * `shouldFallBackToCurrentTimestampWhenUowRowMissing`: Asserts fallback behavior resolves a timestamp within a safe 10-second window of the database current time.
  * `shouldReturnNullForNullLsn`: Asserts that `Lsn.NULL` returns null.
* Executed the integration test suite successfully (all 4 tests passed):
  ```text
  [INFO] Running io.debezium.connector.db2.Db2ConnectionIT
  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.796 s -- in io.debezium.connector.db2.Db2ConnectionIT
  [INFO] io.debezium.connector.db2.Db2ConnectionIT.shouldEnableCdcForDatabase -- Time elapsed: 6.453 s
  [INFO] io.debezium.connector.db2.Db2ConnectionIT.shouldReturnNullForNullLsn -- Time elapsed: 0.172 s
  [INFO] io.debezium.connector.db2.Db2ConnectionIT.shouldReturnCommitTimestampFromUow -- Time elapsed: 0.068 s
  [INFO] io.debezium.connector.db2.Db2ConnectionIT.shouldFallBackToCurrentTimestampWhenUowRowMissing -- Time elapsed: 0.046 s
  ```
